### PR TITLE
set node engine to 6 for heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "env": {
       "mocha": true
     }
+  },
+  "engines": {
+    "node": "^6.6.0"
   }
 }


### PR DESCRIPTION
This tells the Heroku node buildpack to install a newer version of node than the default (which I think is 5)
