### PR TITLE
add a requirable tree of API docs

### DIFF
--- a/build.js
+++ b/build.js
@@ -4,12 +4,13 @@ const packageJSON = require('./package.json')
 const latest = require('gh-latest-release')
 const pify = require('pify')
 const nugget = pify(require('nugget'))
+const objectifyArray = require('objectify-array')
 var version
 var url
 
 latest('electron/electron')
   .then(download)
-  .then(updatePackageJSON)
+  .then(writeFiles)
 
 function download (release) {
   version = release.tag_name.replace('v', '')
@@ -17,11 +18,16 @@ function download (release) {
   return nugget(url, {dir: __dirname})
 }
 
-function updatePackageJSON () {
+function writeFiles () {
   packageJSON.version = version
 
   fs.writeFileSync(
     path.join(__dirname, 'package.json'),
     JSON.stringify(packageJSON, null, 2) + '\n'
+  )
+
+  fs.writeFileSync(
+    path.join(__dirname, 'tree.json'),
+    JSON.stringify(objectifyArray(require('./electron-api.json')), null, 2) + '\n'
   )
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gh-latest-release": "^1.0.0",
     "json": "^9.0.4",
     "nugget": "^2.0.1",
+    "objectify-array": "^1.0.0",
     "pify": "^2.3.0",
     "standard": "^8.1.0",
     "standard-markdown": "^1.2.1",

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,46 @@ docs from Electron v1.4.1.
 
 ## Usage
 
+This module exports structured API data in a few different formats. Choose
+the one that works best for your use case:
+
+### Object Tree Structure
+
+To access the docs as a big object tree:
+
+```js
+const apis = require('electron-api-docs/tree')
+```
+
+This gives you an object with keys for easy traversal:
+
+```js
+apis.BrowserWindow.instanceMethods.setAspectRatio
+```
+
+### Array Structure
+
+To access the docs as an array of API objects:
+
+```js
+const apis = require('electron-api-docs/electron-api.json')
+```
+
+This gives you an array of API objects, so functional methods like `find`,
+`map`, `filter`, and `every` can be used:
+
+```js
+apis.find(api => api.name === 'BrowserWindow')
+apis.filter(api => api.type === 'Class')
+apis.filter(api => api.type === 'Module')
+apis.map(api => api.name)
+```
+
+### Keyed Array Structure
+
+For the best of both worlds (arrays and objects), you can require the module
+as a [keyed array](https://github.com/zeke/keyed-array):
+
 ```js
 const apis = require('electron-api-docs')
 ```
@@ -45,11 +85,8 @@ functional methods like `find`, `map`, `filter`, and `every` can be used:
 
 ```js
 apis.find(api => api.name === 'BrowserWindow')
-
 apis.filter(api => api.type === 'Class')
-
 apis.filter(api => api.type === 'Module')
-
 apis.map(api => api.name)
 
 // All arrays have named keys, not just the top-level array!

--- a/test.js
+++ b/test.js
@@ -1,10 +1,12 @@
 const test = require('tape')
 const apis = require('.')
+const tree = require('./tree')
 
 test('electron-api-docs', function (t) {
   t.ok(Array.isArray(apis), 'is an array')
   t.ok(apis.length > 15, 'contains several API objects')
   t.ok(apis.app, 'gives APIs named keys')
   t.ok(apis.map(api => api.name).indexOf('app') < 3, 'sorts APIs by name')
+  t.ok(tree.BrowserWindow.instanceMethods.setAspectRatio, 'can be required as an object tree structure')
   t.end()
 })

--- a/tree.json
+++ b/tree.json
@@ -1,0 +1,8079 @@
+{
+  "clipboard": {
+    "name": "clipboard",
+    "description": "Perform copy and paste operations on the system clipboard.",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Module",
+    "slug": "clipboard",
+    "websiteUrl": "http://electron.atom.io/docs/api/clipboard",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/clipboard.md",
+    "methods": {
+      "readText": {
+        "name": "readText",
+        "signature": "([type])",
+        "parameters": {
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        },
+        "returns": {
+          "type": "String",
+          "description": "The content in the clipboard as plain text."
+        }
+      },
+      "writeText": {
+        "name": "writeText",
+        "signature": "(text[, type])",
+        "description": "Writes the text into the clipboard as plain text.",
+        "parameters": {
+          "text": {
+            "name": "text",
+            "type": "String"
+          },
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        }
+      },
+      "readHTML": {
+        "name": "readHTML",
+        "signature": "([type])",
+        "parameters": {
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        },
+        "returns": {
+          "type": "String",
+          "description": "The content in the clipboard as markup."
+        }
+      },
+      "writeHTML": {
+        "name": "writeHTML",
+        "signature": "(markup[, type])",
+        "description": "Writes markup to the clipboard.",
+        "parameters": {
+          "markup": {
+            "name": "markup",
+            "type": "String"
+          },
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        }
+      },
+      "readImage": {
+        "name": "readImage",
+        "signature": "([type])",
+        "parameters": {
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        },
+        "returns": {
+          "type": "NativeImage",
+          "description": "The content in the clipboard as a NativeImage."
+        }
+      },
+      "writeImage": {
+        "name": "writeImage",
+        "signature": "(image[, type])",
+        "description": "Writes image to the clipboard.",
+        "parameters": {
+          "image": {
+            "name": "image",
+            "type": "NativeImage"
+          },
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        }
+      },
+      "readRTF": {
+        "name": "readRTF",
+        "signature": "([type])",
+        "parameters": {
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        },
+        "returns": {
+          "type": "String",
+          "description": "The content in the clipboard as RTF."
+        }
+      },
+      "writeRTF": {
+        "name": "writeRTF",
+        "signature": "(text[, type])",
+        "description": "Writes the text into the clipboard in RTF.",
+        "parameters": {
+          "text": {
+            "name": "text",
+            "type": "String"
+          },
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        }
+      },
+      "readBookmark": {
+        "name": "readBookmark",
+        "signature": "()",
+        "platforms": {},
+        "description": "Returns an Object containing title and url keys representing the bookmark in the clipboard. The title and url values will be empty strings when the bookmark is unavailable.",
+        "returns": {
+          "type": "Object",
+          "properties": [
+            {
+              "name": "title",
+              "type": "String",
+              "description": ""
+            },
+            {
+              "name": "url",
+              "type": "String",
+              "description": ""
+            }
+          ]
+        }
+      },
+      "writeBookmark": {
+        "name": "writeBookmark",
+        "signature": "(title, url[, type])",
+        "platforms": {},
+        "description": "Writes the title and url into the clipboard as a bookmark. Note: Most apps on Windows don't support pasting bookmarks into them so you can use clipboard.write to write both a bookmark and fallback text to the clipboard.",
+        "parameters": {
+          "title": {
+            "name": "title",
+            "type": "String"
+          },
+          "url": {
+            "name": "url",
+            "type": "String"
+          },
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        }
+      },
+      "clear": {
+        "name": "clear",
+        "signature": "([type])",
+        "description": "Clears the clipboard content.",
+        "parameters": {
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        }
+      },
+      "availableFormats": {
+        "name": "availableFormats",
+        "signature": "([type])",
+        "parameters": {
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        },
+        "returns": {
+          "type": "String[]",
+          "description": "An array of supported formats for the clipboard type."
+        }
+      },
+      "has": {
+        "name": "has",
+        "signature": "(data[, type])",
+        "platforms": {},
+        "parameters": {
+          "data": {
+            "name": "data",
+            "type": "String"
+          },
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the clipboard supports the format of specified data."
+        }
+      },
+      "read": {
+        "name": "read",
+        "signature": "(data[, type])",
+        "platforms": {},
+        "parameters": {
+          "data": {
+            "name": "data",
+            "type": "String"
+          },
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        },
+        "returns": {
+          "type": "String",
+          "description": "Reads data from the clipboard."
+        }
+      },
+      "write": {
+        "name": "write",
+        "signature": "(data[, type])",
+        "description": "Writes data to the clipboard.",
+        "parameters": {
+          "data": {
+            "name": "data",
+            "type": "Object",
+            "properties": {
+              "text": {
+                "name": "text",
+                "type": "String",
+                "description": ""
+              },
+              "html": {
+                "name": "html",
+                "type": "String",
+                "description": ""
+              },
+              "image": {
+                "name": "image",
+                "type": "NativeImage",
+                "description": ""
+              },
+              "rtf": {
+                "name": "rtf",
+                "type": "String",
+                "description": ""
+              },
+              "bookmark": {
+                "name": "bookmark",
+                "type": "String",
+                "description": "The title of the url at ."
+              }
+            }
+          },
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional)"
+          }
+        }
+      }
+    }
+  },
+  "crashReporter": {
+    "name": "crashReporter",
+    "description": "Submit crash reports to a remote server.",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Module",
+    "slug": "crash-reporter",
+    "websiteUrl": "http://electron.atom.io/docs/api/crash-reporter",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/crash-reporter.md",
+    "methods": {
+      "start": {
+        "name": "start",
+        "signature": "(options)",
+        "description": "You are required to call this method before using other crashReporter APIs. Note: On macOS, Electron uses a new crashpad client, which is different from breakpad on Windows and Linux. To enable the crash collection feature, you are required to call the crashReporter.start API to initialize crashpad in the main process and in each renderer process from which you wish to collect crash reports.",
+        "parameters": {
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "properties": {
+              "companyName": {
+                "name": "companyName",
+                "type": "String",
+                "description": ""
+              },
+              "submitURL": {
+                "name": "submitURL",
+                "type": "String",
+                "description": "URL that crash reports will be sent to as POST."
+              },
+              "productName": {
+                "name": "productName",
+                "type": "String",
+                "description": "(optional) - Defaults to ."
+              },
+              "autoSubmit": {
+                "name": "autoSubmit",
+                "type": "Boolean",
+                "description": "Send the crash report without user interaction. Default is ."
+              },
+              "ignoreSystemCrashHandler": {
+                "name": "ignoreSystemCrashHandler",
+                "type": "Boolean",
+                "description": "Default is ."
+              },
+              "extra": {
+                "name": "extra",
+                "type": "Object",
+                "description": "An object you can define that will be sent along with the report. Only string properties are sent correctly, Nested objects are not supported.",
+                "properties": {}
+              }
+            }
+          }
+        }
+      },
+      "getLastCrashReport": {
+        "name": "getLastCrashReport",
+        "signature": "()",
+        "description": "Returns the date and ID of the last crash report. If no crash reports have been sent or the crash reporter has not been started, null is returned.",
+        "returns": {
+          "type": "Object",
+          "properties": [
+            {
+              "name": "date",
+              "type": "String",
+              "description": ""
+            },
+            {
+              "name": "ID",
+              "type": "Integer",
+              "description": ""
+            }
+          ]
+        }
+      },
+      "getUploadedReports": {
+        "name": "getUploadedReports",
+        "signature": "()",
+        "description": "Returns all uploaded crash reports. Each report contains the date and uploaded ID.",
+        "returns": {
+          "type": "Object[]"
+        }
+      }
+    }
+  },
+  "nativeImage": {
+    "name": "nativeImage",
+    "description": "Create tray, dock, and application icons using PNG or JPG files.",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Module",
+    "slug": "native-image",
+    "websiteUrl": "http://electron.atom.io/docs/api/native-image",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/native-image.md",
+    "methods": {
+      "createEmpty": {
+        "name": "createEmpty",
+        "signature": "()",
+        "description": "Creates an empty NativeImage instance.",
+        "returns": {
+          "type": "NativeImage"
+        }
+      },
+      "createFromPath": {
+        "name": "createFromPath",
+        "signature": "(path)",
+        "description": "Creates a new NativeImage instance from a file located at path. This method returns an empty image if the path does not exist, cannot be read, or is not a valid image.",
+        "parameters": {
+          "path": {
+            "name": "path",
+            "type": "String"
+          }
+        },
+        "returns": {
+          "type": "NativeImage"
+        }
+      },
+      "createFromBuffer": {
+        "name": "createFromBuffer",
+        "signature": "(buffer[, scaleFactor])",
+        "description": "Creates a new NativeImage instance from buffer. The default scaleFactor is 1.0.",
+        "parameters": {
+          "buffer": {
+            "name": "buffer",
+            "type": "Buffer"
+          },
+          "scaleFactor": {
+            "name": "scaleFactor",
+            "type": "Double",
+            "description": "(optional)"
+          }
+        },
+        "returns": {
+          "type": "NativeImage"
+        }
+      },
+      "createFromDataURL": {
+        "name": "createFromDataURL",
+        "signature": "(dataURL)",
+        "description": "Creates a new NativeImage instance from dataURL.",
+        "parameters": {
+          "dataURL": {
+            "name": "dataURL",
+            "type": "String"
+          }
+        }
+      }
+    }
+  },
+  "NativeImage": {
+    "name": "NativeImage",
+    "description": "Natively wrap images such as tray, dock, and application icons.",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Class",
+    "slug": "native-image",
+    "websiteUrl": "http://electron.atom.io/docs/api/native-image",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/native-image.md",
+    "instanceName": "image",
+    "instanceMethods": {
+      "toPNG": {
+        "name": "toPNG",
+        "signature": "()",
+        "returns": {
+          "type": "Buffer",
+          "description": "A Buffer that contains the image's PNG encoded data."
+        }
+      },
+      "toJPEG": {
+        "name": "toJPEG",
+        "signature": "(quality)",
+        "parameters": {
+          "quality": {
+            "name": "quality",
+            "type": "Integer",
+            "description": "() - Between 0 - 100."
+          }
+        },
+        "returns": {
+          "type": "Buffer",
+          "description": "A Buffer that contains the image's JPEG encoded data."
+        }
+      },
+      "toBitmap": {
+        "name": "toBitmap",
+        "signature": "()",
+        "returns": {
+          "type": "Buffer",
+          "description": "A Buffer that contains a copy of the image's raw bitmap pixel data."
+        }
+      },
+      "toDataURL": {
+        "name": "toDataURL",
+        "signature": "()",
+        "returns": {
+          "type": "String",
+          "description": "The data URL of the image."
+        }
+      },
+      "getBitmap": {
+        "name": "getBitmap",
+        "signature": "()",
+        "description": "The difference between getBitmap() and toBitmap() is, getBitmap() does not copy the bitmap data, so you have to use the returned Buffer immediately in current event loop tick, otherwise the data might be changed or destroyed.",
+        "returns": {
+          "type": "Buffer",
+          "description": "A Buffer that contains the image's raw bitmap pixel data."
+        }
+      },
+      "getNativeHandle": {
+        "name": "getNativeHandle",
+        "signature": "()",
+        "platforms": {},
+        "description": "Notice that the returned pointer is a weak pointer to the underlying native image instead of a copy, so you must ensure that the associated nativeImage instance is kept around.",
+        "returns": {
+          "type": "Buffer",
+          "description": "A Buffer that stores C pointer to underlying native handle of the image. On macOS, a pointer to NSImage instance would be returned."
+        }
+      },
+      "isEmpty": {
+        "name": "isEmpty",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the image is empty."
+        }
+      },
+      "getSize": {
+        "name": "getSize",
+        "signature": "()",
+        "returns": {
+          "type": "Object",
+          "properties": [
+            {
+              "name": "width",
+              "type": "Integer",
+              "description": ""
+            },
+            {
+              "name": "height",
+              "type": "Integer",
+              "description": ""
+            }
+          ]
+        }
+      },
+      "setTemplateImage": {
+        "name": "setTemplateImage",
+        "signature": "(option)",
+        "description": "Marks the image as a template image.",
+        "parameters": {
+          "option": {
+            "name": "option",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isTemplateImage": {
+        "name": "isTemplateImage",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the image is a template image."
+        }
+      },
+      "crop": {
+        "name": "crop",
+        "signature": "(rect)",
+        "parameters": {
+          "rect": {
+            "name": "rect",
+            "type": "Object",
+            "description": "The area of the image to crop",
+            "properties": {
+              "x": {
+                "name": "x",
+                "type": "Integer",
+                "description": ""
+              },
+              "y": {
+                "name": "y",
+                "type": "Integer",
+                "description": ""
+              },
+              "width": {
+                "name": "width",
+                "type": "Integer",
+                "description": ""
+              },
+              "height": {
+                "name": "height",
+                "type": "Integer",
+                "description": ""
+              }
+            }
+          }
+        },
+        "returns": {
+          "type": "NativeImage",
+          "description": "The cropped image."
+        }
+      },
+      "resize": {
+        "name": "resize",
+        "signature": "(options)",
+        "description": "If only the height or the width are specified then the current aspect ratio will be preserved in the resized image.",
+        "parameters": {
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "properties": {
+              "width": {
+                "name": "width",
+                "type": "Integer",
+                "description": "(optional)"
+              },
+              "height": {
+                "name": "height",
+                "type": "Integer",
+                "description": "(optional)"
+              },
+              "quality": {
+                "name": "quality",
+                "type": "String",
+                "description": "(optional) - The desired quality of the resize image. Possible values are , or . The default is . These values express a desired quality/speed tradeoff. They are translated into an algorithm-specific method that depends on the capabilities (CPU, GPU) of the underlying platform. It is possible for all three methods to be mapped to the same algorithm on a given platform."
+              }
+            }
+          }
+        },
+        "returns": {
+          "type": "NativeImage",
+          "description": "The resized image."
+        }
+      },
+      "getAspectRatio": {
+        "name": "getAspectRatio",
+        "signature": "()",
+        "returns": {
+          "type": "Float",
+          "description": "The image's aspect ratio."
+        }
+      }
+    }
+  },
+  "shell": {
+    "name": "shell",
+    "description": "Manage files and URLs using their default applications.",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Module",
+    "slug": "shell",
+    "websiteUrl": "http://electron.atom.io/docs/api/shell",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/shell.md",
+    "methods": {
+      "showItemInFolder": {
+        "name": "showItemInFolder",
+        "signature": "(fullPath)",
+        "description": "Show the given file in a file manager. If possible, select the file.",
+        "parameters": {
+          "fullPath": {
+            "name": "fullPath",
+            "type": "String"
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the item was successfully shown"
+        }
+      },
+      "openItem": {
+        "name": "openItem",
+        "signature": "(fullPath)",
+        "description": "Open the given file in the desktop's default manner.",
+        "parameters": {
+          "fullPath": {
+            "name": "fullPath",
+            "type": "String"
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the item was successfully opened."
+        }
+      },
+      "openExternal": {
+        "name": "openExternal",
+        "signature": "(url[, options])",
+        "description": "Open the given external protocol URL in the desktop's default manner. (For example, mailto: URLs in the user's default mail agent).",
+        "parameters": {
+          "url": {
+            "name": "url",
+            "type": "String"
+          },
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "description": "(optional)",
+            "properties": {
+              "activate": {
+                "name": "activate",
+                "type": "Boolean",
+                "description": "to bring the opened application to the foreground. The default is ."
+              }
+            }
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether an application was available to open the URL."
+        }
+      },
+      "moveItemToTrash": {
+        "name": "moveItemToTrash",
+        "signature": "(fullPath)",
+        "description": "Move the given file to trash and returns a boolean status for the operation.",
+        "parameters": {
+          "fullPath": {
+            "name": "fullPath",
+            "type": "String"
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the item was successfully moved to the trash"
+        }
+      },
+      "beep": {
+        "name": "beep",
+        "signature": "()",
+        "description": "Play the beep sound."
+      },
+      "writeShortcutLink": {
+        "name": "writeShortcutLink",
+        "signature": "(shortcutPath[, operation], options)",
+        "platforms": {},
+        "description": "Creates or updates a shortcut link at shortcutPath.",
+        "parameters": {
+          "shortcutPath": {
+            "name": "shortcutPath",
+            "type": "String"
+          },
+          "operation": {
+            "name": "operation",
+            "type": "String",
+            "description": "(optional) - Default is `create`, can be one of following:",
+            "possibleValues": {}
+          },
+          "options": {
+            "name": "options",
+            "type": "ShortcutDetails"
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the shortcut was created successfully"
+        }
+      },
+      "readShortcutLink": {
+        "name": "readShortcutLink",
+        "signature": "(shortcutPath)",
+        "platforms": {},
+        "description": "Resolves the shortcut link at shortcutPath. An exception will be thrown when any error happens.",
+        "parameters": {
+          "shortcutPath": {
+            "name": "shortcutPath",
+            "type": "String"
+          }
+        },
+        "returns": {
+          "type": "ShortcutDetails"
+        }
+      }
+    }
+  },
+  "app": {
+    "name": "app",
+    "description": "Control your application's event lifecycle.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Module",
+    "slug": "app",
+    "websiteUrl": "http://electron.atom.io/docs/api/app",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/app.md",
+    "methods": {
+      "quit": {
+        "name": "quit",
+        "signature": "()",
+        "description": "Try to close all windows. The before-quit event will be emitted first. If all windows are successfully closed, the will-quit event will be emitted and by default the application will terminate. This method guarantees that all beforeunload and unload event handlers are correctly executed. It is possible that a window cancels the quitting by returning false in the beforeunload event handler."
+      },
+      "exit": {
+        "name": "exit",
+        "signature": "([exitCode])",
+        "description": "Exits immediately with exitCode.  exitCode defaults to 0. All windows will be closed immediately without asking user and the before-quit and will-quit events will not be emitted.",
+        "parameters": {
+          "exitCode": {
+            "name": "exitCode",
+            "type": "Integer",
+            "description": "(optional)"
+          }
+        }
+      },
+      "relaunch": {
+        "name": "relaunch",
+        "signature": "([options])",
+        "description": "Relaunches the app when current instance exits. By default the new instance will use the same working directory and command line arguments with current instance. When args is specified, the args will be passed as command line arguments instead. When execPath is specified, the execPath will be executed for relaunch instead of current app. Note that this method does not quit the app when executed, you have to call app.quit or app.exit after calling app.relaunch to make the app restart. When app.relaunch is called for multiple times, multiple instances will be started after current instance exited. An example of restarting current instance immediately and adding a new command line argument to the new instance:",
+        "parameters": {
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "description": "(optional)",
+            "properties": {
+              "args": {
+                "name": "args",
+                "type": "String[]",
+                "description": "(optional)"
+              },
+              "execPath": {
+                "name": "execPath",
+                "type": "String",
+                "description": "(optional)"
+              }
+            }
+          }
+        }
+      },
+      "isReady": {
+        "name": "isReady",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "true if Electron has finished initializing, false otherwise."
+        }
+      },
+      "focus": {
+        "name": "focus",
+        "signature": "()",
+        "description": "On Linux, focuses on the first visible window. On macOS, makes the application the active app. On Windows, focuses on the application's first window."
+      },
+      "hide": {
+        "name": "hide",
+        "signature": "()",
+        "platforms": {},
+        "description": "Hides the dock icon."
+      },
+      "show": {
+        "name": "show",
+        "signature": "()",
+        "platforms": {},
+        "description": "Shows the dock icon."
+      },
+      "getAppPath": {
+        "name": "getAppPath",
+        "signature": "()",
+        "returns": {
+          "type": "String",
+          "description": "The current application directory."
+        }
+      },
+      "getPath": {
+        "name": "getPath",
+        "signature": "(name)",
+        "description": "You can request the following paths by the name:",
+        "parameters": {
+          "name": {
+            "name": "name",
+            "type": "String"
+          }
+        },
+        "returns": {
+          "type": "String",
+          "description": "A path to a special directory or file associated with name. On failure an Error is thrown."
+        }
+      },
+      "setPath": {
+        "name": "setPath",
+        "signature": "(name, path)",
+        "description": "Overrides the path to a special directory or file associated with name. If the path specifies a directory that does not exist, the directory will be created by this method. On failure an Error is thrown. You can only override paths of a name defined in app.getPath. By default, web pages' cookies and caches will be stored under the userData directory. If you want to change this location, you have to override the userData path before the ready event of the app module is emitted.",
+        "parameters": {
+          "name": {
+            "name": "name",
+            "type": "String"
+          },
+          "path": {
+            "name": "path",
+            "type": "String"
+          }
+        }
+      },
+      "getVersion": {
+        "name": "getVersion",
+        "signature": "()",
+        "returns": {
+          "type": "String",
+          "description": "The version of the loaded application. If no version is found in the application's package.json file, the version of the current bundle or executable is returned."
+        }
+      },
+      "getName": {
+        "name": "getName",
+        "signature": "()",
+        "description": "Usually the name field of package.json is a short lowercased name, according to the npm modules spec. You should usually also specify a productName field, which is your application's full capitalized name, and which will be preferred over name by Electron.",
+        "returns": {
+          "type": "String",
+          "description": "The current application's name, which is the name in the application's package.json file."
+        }
+      },
+      "setName": {
+        "name": "setName",
+        "signature": "(name)",
+        "description": "Overrides the current application's name.",
+        "parameters": {
+          "name": {
+            "name": "name",
+            "type": "String"
+          }
+        }
+      },
+      "getLocale": {
+        "name": "getLocale",
+        "signature": "()",
+        "description": "Note: When distributing your packaged app, you have to also ship the locales folder. Note: On Windows you have to call it after the ready events gets emitted.",
+        "returns": {
+          "type": "String",
+          "description": "The current application locale. Possible return values are documented here."
+        }
+      },
+      "addRecentDocument": {
+        "name": "addRecentDocument",
+        "signature": "(path)",
+        "platforms": {},
+        "description": "Adds path to the recent documents list. This list is managed by the OS. On Windows you can visit the list from the task bar, and on macOS you can visit it from dock menu.",
+        "parameters": {
+          "path": {
+            "name": "path",
+            "type": "String"
+          }
+        }
+      },
+      "clearRecentDocuments": {
+        "name": "clearRecentDocuments",
+        "signature": "()",
+        "platforms": {},
+        "description": "Clears the recent documents list."
+      },
+      "setAsDefaultProtocolClient": {
+        "name": "setAsDefaultProtocolClient",
+        "signature": "(protocol[, path, args])",
+        "platforms": {},
+        "description": "This method sets the current executable as the default handler for a protocol (aka URI scheme). It allows you to integrate your app deeper into the operating system. Once registered, all links with your-protocol:// will be opened with the current executable. The whole link, including protocol, will be passed to your application as a parameter. On Windows you can provide optional parameters path, the path to your executable, and args, an array of arguments to be passed to your executable when it launches. Note: On macOS, you can only register protocols that have been added to your app's info.plist, which can not be modified at runtime. You can however change the file with a simple text editor or script during build time. Please refer to Apple's documentation for details. The API uses the Windows Registry and LSSetDefaultHandlerForURLScheme internally.",
+        "parameters": {
+          "protocol": {
+            "name": "protocol",
+            "type": "String",
+            "description": "The name of your protocol, without `://`. If you want your app to handle `electron://` links, call this method with `electron` as the parameter."
+          },
+          "path": {
+            "name": "path",
+            "type": "String",
+            "description": "(optional) - Defaults to `process.execPath`"
+          },
+          "args": {
+            "name": "args",
+            "type": "String[]",
+            "description": "(optional) - Defaults to an empty array"
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the call succeeded."
+        }
+      },
+      "removeAsDefaultProtocolClient": {
+        "name": "removeAsDefaultProtocolClient",
+        "signature": "(protocol[, path, args])",
+        "platforms": {},
+        "description": "This method checks if the current executable as the default handler for a protocol (aka URI scheme). If so, it will remove the app as the default handler.",
+        "parameters": {
+          "protocol": {
+            "name": "protocol",
+            "type": "String",
+            "description": "The name of your protocol, without `://`."
+          },
+          "path": {
+            "name": "path",
+            "type": "String",
+            "description": "(optional) - Defaults to `process.execPath`"
+          },
+          "args": {
+            "name": "args",
+            "type": "String[]",
+            "description": "(optional) - Defaults to an empty array"
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the call succeeded."
+        }
+      },
+      "isDefaultProtocolClient": {
+        "name": "isDefaultProtocolClient",
+        "signature": "(protocol[, path, args])",
+        "platforms": {},
+        "description": "This method checks if the current executable is the default handler for a protocol (aka URI scheme). If so, it will return true. Otherwise, it will return false. Note: On macOS, you can use this method to check if the app has been registered as the default protocol handler for a protocol. You can also verify this by checking ~/Library/Preferences/com.apple.LaunchServices.plist on the macOS machine. Please refer to Apple's documentation for details. The API uses the Windows Registry and LSCopyDefaultHandlerForURLScheme internally.",
+        "parameters": {
+          "protocol": {
+            "name": "protocol",
+            "type": "String",
+            "description": "The name of your protocol, without `://`."
+          },
+          "path": {
+            "name": "path",
+            "type": "String",
+            "description": "(optional) - Defaults to `process.execPath`"
+          },
+          "args": {
+            "name": "args",
+            "type": "String[]",
+            "description": "(optional) - Defaults to an empty array"
+          }
+        },
+        "returns": {
+          "type": "Boolean"
+        }
+      },
+      "setUserTasks": {
+        "name": "setUserTasks",
+        "signature": "(tasks)",
+        "platforms": {},
+        "description": "Adds tasks to the Tasks category of the JumpList on Windows. tasks is an array of Task objects in the following format: Task Object: Note: If you'd like to customize the Jump List even more use app.setJumpList(categories) instead.",
+        "parameters": {
+          "tasks": {
+            "name": "tasks",
+            "type": "Task[]",
+            "description": "Array of `Task` objects"
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the call succeeded."
+        }
+      },
+      "getJumpListSettings": {
+        "name": "getJumpListSettings",
+        "signature": "()",
+        "platforms": {},
+        "returns": {
+          "type": "Object",
+          "properties": [
+            {
+              "name": "minItems",
+              "type": "Integer",
+              "description": "The minimum number of items that will be shown in the Jump List (for a more detailed description of this value see the )."
+            },
+            {
+              "name": "removedItems",
+              "type": "JumpListItem[]",
+              "description": "Array of objects that correspond to items that the user has explicitly removed from custom categories in the Jump List. These items must not be re-added to the Jump List in the call to , Windows will not display any custom category that contains any of the removed items."
+            }
+          ]
+        }
+      },
+      "setJumpList": {
+        "name": "setJumpList",
+        "signature": "(categories)",
+        "platforms": {},
+        "description": "Sets or removes a custom Jump List for the application, and returns one of the following strings: If categories is null the previously set custom Jump List (if any) will be replaced by the standard Jump List for the app (managed by Windows). JumpListCategory objects should have the following properties: Note: If a JumpListCategory object has neither the type nor the name property set then its type is assumed to be tasks. If the name property is set but the type property is omitted then the type is assumed to be custom. Note: Users can remove items from custom categories, and Windows will not allow a removed item to be added back into a custom category until after the next successful call to app.setJumpList(categories). Any attempt to re-add a removed item to a custom category earlier than that will result in the entire custom category being omitted from the Jump List. The list of removed items can be obtained using app.getJumpListSettings(). JumpListItem objects should have the following properties: Here's a very simple example of creating a custom Jump List:",
+        "parameters": {
+          "categories": {
+            "name": "categories",
+            "type": "JumpListCategory[]",
+            "description": "or `null` - Array of `JumpListCategory` objects."
+          }
+        }
+      },
+      "makeSingleInstance": {
+        "name": "makeSingleInstance",
+        "signature": "(callback)",
+        "description": "This method makes your application a Single Instance Application - instead of allowing multiple instances of your app to run, this will ensure that only a single instance of your app is running, and other instances signal this instance and exit. callback will be called with callback(argv, workingDirectory) when a second instance has been executed. argv is an Array of the second instance's command line arguments, and workingDirectory is its current working directory. Usually applications respond to this by making their primary window focused and non-minimized. The callback is guaranteed to be executed after the ready event of app gets emitted. This method returns false if your process is the primary instance of the application and your app should continue loading. And returns true if your process has sent its parameters to another instance, and you should immediately quit. On macOS the system enforces single instance automatically when users try to open a second instance of your app in Finder, and the open-file and open-url events will be emitted for that. However when users start your app in command line the system's single instance mechanism will be bypassed and you have to use this method to ensure single instance. An example of activating the window of primary instance when a second instance starts:",
+        "parameters": {
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "releaseSingleInstance": {
+        "name": "releaseSingleInstance",
+        "signature": "()",
+        "description": "Releases all locks that were created by makeSingleInstance. This will allow multiple instances of the application to once again run side by side."
+      },
+      "setUserActivity": {
+        "name": "setUserActivity",
+        "signature": "(type, userInfo[, webpageURL])",
+        "platforms": {},
+        "description": "Creates an NSUserActivity and sets it as the current activity. The activity is eligible for Handoff to another device afterward.",
+        "parameters": {
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "Uniquely identifies the activity. Maps to ."
+          },
+          "userInfo": {
+            "name": "userInfo",
+            "type": "Object",
+            "description": "App-specific state to store for use by another device."
+          },
+          "webpageURL": {
+            "name": "webpageURL",
+            "type": "String",
+            "description": "The webpage to load in a browser if no suitable app is installed on the resuming device. The scheme must be `http` or `https`."
+          }
+        }
+      },
+      "getCurrentActivityType": {
+        "name": "getCurrentActivityType",
+        "signature": "()",
+        "platforms": {},
+        "returns": {
+          "type": "String",
+          "description": "The type of the currently running activity."
+        }
+      },
+      "setAppUserModelId": {
+        "name": "setAppUserModelId",
+        "signature": "(id)",
+        "platforms": {},
+        "description": "Changes the Application User Model ID to id.",
+        "parameters": {
+          "id": {
+            "name": "id",
+            "type": "String"
+          }
+        }
+      },
+      "importCertificate": {
+        "name": "importCertificate",
+        "signature": "(options, callback)",
+        "platforms": {},
+        "description": "Imports the certificate in pkcs12 format into the platform certificate store. callback is called with the result of import operation, a value of 0 indicates success while any other value indicates failure according to chromium net_error_list.",
+        "parameters": {
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "properties": {
+              "certificate": {
+                "name": "certificate",
+                "type": "String",
+                "description": "Path for the pkcs12 file."
+              },
+              "password": {
+                "name": "password",
+                "type": "String",
+                "description": "Passphrase for the certificate."
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "disableHardwareAcceleration": {
+        "name": "disableHardwareAcceleration",
+        "signature": "()",
+        "description": "Disables hardware acceleration for current app. This method can only be called before app is ready."
+      },
+      "setBadgeCount": {
+        "name": "setBadgeCount",
+        "signature": "(count)",
+        "platforms": {},
+        "description": "Sets the counter badge for current app. Setting the count to 0 will hide the badge. On macOS it shows on the dock icon. On Linux it only works for Unity launcher, Note: Unity launcher requires the exsistence of a .desktop file to work, for more information please read Desktop Environment Integration.",
+        "parameters": {
+          "count": {
+            "name": "count",
+            "type": "Integer"
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the call succeeded."
+        }
+      },
+      "getBadgeCount": {
+        "name": "getBadgeCount",
+        "signature": "()",
+        "platforms": {},
+        "returns": {
+          "type": "Integer",
+          "description": "The current value displayed in the counter badge."
+        }
+      },
+      "isUnityRunning": {
+        "name": "isUnityRunning",
+        "signature": "()",
+        "platforms": {},
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the current desktop environment is Unity launcher."
+        }
+      },
+      "getLoginItemSettings": {
+        "name": "getLoginItemSettings",
+        "signature": "()",
+        "platforms": {},
+        "description": "Note: This API has no effect on MAS builds.",
+        "returns": {
+          "type": "Object",
+          "properties": [
+            {
+              "name": "openAtLogin",
+              "type": "Boolean",
+              "description": "if the app is set to open at login."
+            },
+            {
+              "name": "openAsHidden",
+              "type": "Boolean",
+              "description": "if the app is set to open as hidden at login. This setting is only supported on macOS."
+            },
+            {
+              "name": "wasOpenedAtLogin",
+              "type": "Boolean",
+              "description": "if the app was opened at login automatically. This setting is only supported on macOS."
+            },
+            {
+              "name": "wasOpenedAsHidden",
+              "type": "Boolean",
+              "description": "if the app was opened as a hidden login item. This indicates that the app should not open any windows at startup. This setting is only supported on macOS."
+            },
+            {
+              "name": "restoreState",
+              "type": "Boolean",
+              "description": "if the app was opened as a login item that should restore the state from the previous session. This indicates that the app should restore the windows that were open the last time the app was closed. This setting is only supported on macOS."
+            }
+          ]
+        }
+      },
+      "setLoginItemSettings": {
+        "name": "setLoginItemSettings",
+        "signature": "(settings)",
+        "platforms": {},
+        "description": "Set the app's login item settings. Note: This API has no effect on MAS builds.",
+        "parameters": {
+          "settings": {
+            "name": "settings",
+            "type": "Object",
+            "properties": {
+              "openAtLogin": {
+                "name": "openAtLogin",
+                "type": "Boolean",
+                "description": "to open the app at login, to remove the app as a login item. Defaults to ."
+              },
+              "openAsHidden": {
+                "name": "openAsHidden",
+                "type": "Boolean",
+                "description": "to open the app as hidden. Defaults to . The user can edit this setting from the System Preferences so should be checked when the app is opened to know the current value. This setting is only supported on macOS."
+              }
+            }
+          }
+        }
+      },
+      "isAccessibilitySupportEnabled": {
+        "name": "isAccessibilitySupportEnabled",
+        "signature": "()",
+        "platforms": {},
+        "returns": {
+          "type": "Boolean",
+          "description": "true if Chrome's accessibility support is enabled, false otherwise. This API will return true if the use of assistive technologies, such as screen readers, has been detected. See https://www.chromium.org/developers/design-documents/accessibility for more details."
+        }
+      },
+      "setAboutPanelOptions": {
+        "name": "setAboutPanelOptions",
+        "signature": "(options)",
+        "platforms": {},
+        "description": "Set the about panel options. This will override the values defined in the app's .plist file. See the Apple docs for more details.",
+        "parameters": {
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "properties": {
+              "applicationName": {
+                "name": "applicationName",
+                "type": "String",
+                "description": "(optional) - The app's name."
+              },
+              "applicationVersion": {
+                "name": "applicationVersion",
+                "type": "String",
+                "description": "(optional) - The app's version."
+              },
+              "copyright": {
+                "name": "copyright",
+                "type": "String",
+                "description": "(optional) - Copyright information."
+              },
+              "credits": {
+                "name": "credits",
+                "type": "String",
+                "description": "(optional) - Credit information."
+              },
+              "version": {
+                "name": "version",
+                "type": "String",
+                "description": "(optional) - The app's build version number."
+              }
+            }
+          }
+        }
+      },
+      "appendSwitch": {
+        "name": "appendSwitch",
+        "signature": "(switch[, value])",
+        "description": "Append a switch (with optional value) to Chromium's command line. Note: This will not affect process.argv, and is mainly used by developers to control some low-level Chromium behaviors.",
+        "parameters": {
+          "switch": {
+            "name": "switch",
+            "type": "String",
+            "description": "A command-line switch"
+          },
+          "value": {
+            "name": "value",
+            "type": "String",
+            "description": "(optional) - A value for the given switch"
+          }
+        }
+      },
+      "appendArgument": {
+        "name": "appendArgument",
+        "signature": "(value)",
+        "description": "Append an argument to Chromium's command line. The argument will be quoted correctly. Note: This will not affect process.argv.",
+        "parameters": {
+          "value": {
+            "name": "value",
+            "type": "String",
+            "description": "The argument to append to the command line"
+          }
+        }
+      },
+      "bounce": {
+        "name": "bounce",
+        "signature": "([type])",
+        "platforms": {},
+        "description": "When critical is passed, the dock icon will bounce until either the application becomes active or the request is canceled. When informational is passed, the dock icon will bounce for one second. However, the request remains active until either the application becomes active or the request is canceled. Returns an ID representing the request.",
+        "parameters": {
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "(optional) - Can be `critical` or `informational`. The default is `informational`"
+          }
+        }
+      },
+      "cancelBounce": {
+        "name": "cancelBounce",
+        "signature": "(id)",
+        "platforms": {},
+        "description": "Cancel the bounce of id.",
+        "parameters": {
+          "id": {
+            "name": "id",
+            "type": "Integer"
+          }
+        }
+      },
+      "downloadFinished": {
+        "name": "downloadFinished",
+        "signature": "(filePath)",
+        "platforms": {},
+        "description": "Bounces the Downloads stack if the filePath is inside the Downloads folder.",
+        "parameters": {
+          "filePath": {
+            "name": "filePath",
+            "type": "String"
+          }
+        }
+      },
+      "setBadge": {
+        "name": "setBadge",
+        "signature": "(text)",
+        "platforms": {},
+        "description": "Sets the string to be displayed in the dock’s badging area.",
+        "parameters": {
+          "text": {
+            "name": "text",
+            "type": "String"
+          }
+        }
+      },
+      "getBadge": {
+        "name": "getBadge",
+        "signature": "()",
+        "platforms": {},
+        "returns": {
+          "type": "String",
+          "description": "The badge string of the dock."
+        }
+      },
+      "isVisible": {
+        "name": "isVisible",
+        "signature": "()",
+        "platforms": {},
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the dock icon is visible. The app.dock.show() call is asynchronous so this method might not return true immediately after that call."
+        }
+      },
+      "setMenu": {
+        "name": "setMenu",
+        "signature": "(menu)",
+        "platforms": {},
+        "description": "Sets the application's dock menu.",
+        "parameters": {
+          "menu": {
+            "name": "menu",
+            "type": "Menu"
+          }
+        }
+      },
+      "setIcon": {
+        "name": "setIcon",
+        "signature": "(image)",
+        "platforms": {},
+        "description": "Sets the image associated with this dock icon.",
+        "parameters": {
+          "image": {
+            "name": "image",
+            "type": "NativeImage"
+          }
+        }
+      }
+    },
+    "events": {
+      "will-finish-launching": {
+        "name": "will-finish-launching",
+        "description": "Emitted when the application has finished basic startup. On Windows and Linux, the will-finish-launching event is the same as the ready event; on macOS, this event represents the applicationWillFinishLaunching notification of NSApplication. You would usually set up listeners for the open-file and open-url events here, and start the crash reporter and auto updater. In most cases, you should just do everything in the ready event handler."
+      },
+      "ready": {
+        "name": "ready",
+        "description": "Emitted when Electron has finished initializing. On macOS, launchInfo holds the userInfo of the NSUserNotification that was used to open the application, if it was launched from Notification Center. You can call app.isReady() to check if this event has already fired.",
+        "returns": {
+          "launchInfo": {
+            "name": "launchInfo",
+            "type": "Object"
+          }
+        }
+      },
+      "window-all-closed": {
+        "name": "window-all-closed",
+        "description": "Emitted when all windows have been closed. If you do not subscribe to this event and all windows are closed, the default behavior is to quit the app; however, if you subscribe, you control whether the app quits or not. If the user pressed Cmd + Q, or the developer called app.quit(), Electron will first try to close all the windows and then emit the will-quit event, and in this case the window-all-closed event would not be emitted."
+      },
+      "before-quit": {
+        "name": "before-quit",
+        "description": "Emitted before the application starts closing its windows. Calling event.preventDefault() will prevent the default behaviour, which is terminating the application.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          }
+        }
+      },
+      "will-quit": {
+        "name": "will-quit",
+        "description": "Emitted when all windows have been closed and the application will quit. Calling event.preventDefault() will prevent the default behaviour, which is terminating the application. See the description of the window-all-closed event for the differences between the will-quit and window-all-closed events.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          }
+        }
+      },
+      "quit": {
+        "name": "quit",
+        "description": "Emitted when the application is quitting.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "exitCode": {
+            "name": "exitCode",
+            "type": "Integer"
+          }
+        }
+      },
+      "open-file": {
+        "name": "open-file",
+        "description": "Emitted when the user wants to open a file with the application. The open-file event is usually emitted when the application is already open and the OS wants to reuse the application to open the file. open-file is also emitted when a file is dropped onto the dock and the application is not yet running. Make sure to listen for the open-file event very early in your application startup to handle this case (even before the ready event is emitted). You should call event.preventDefault() if you want to handle this event. On Windows, you have to parse process.argv (in the main process) to get the filepath.",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "path": {
+            "name": "path",
+            "type": "String"
+          }
+        }
+      },
+      "open-url": {
+        "name": "open-url",
+        "description": "Emitted when the user wants to open a URL with the application. The URL scheme must be registered to be opened by your application. You should call event.preventDefault() if you want to handle this event.",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "url": {
+            "name": "url",
+            "type": "String"
+          }
+        }
+      },
+      "activate": {
+        "name": "activate",
+        "description": "Emitted when the application is activated, which usually happens when the user clicks on the application's dock icon.",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "hasVisibleWindows": {
+            "name": "hasVisibleWindows",
+            "type": "Boolean"
+          }
+        }
+      },
+      "continue-activity": {
+        "name": "continue-activity",
+        "description": "Emitted during Handoff when an activity from a different device wants to be resumed. You should call event.preventDefault() if you want to handle this event. A user activity can be continued only in an app that has the same developer Team ID as the activity's source app and that supports the activity's type. Supported activity types are specified in the app's Info.plist under the NSUserActivityTypes key.",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "A string identifying the activity. Maps to ."
+          },
+          "userInfo": {
+            "name": "userInfo",
+            "type": "Object",
+            "description": "Contains app-specific state stored by the activity on another device."
+          }
+        }
+      },
+      "browser-window-blur": {
+        "name": "browser-window-blur",
+        "description": "Emitted when a browserWindow gets blurred.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "window": {
+            "name": "window",
+            "type": "BrowserWindow"
+          }
+        }
+      },
+      "browser-window-focus": {
+        "name": "browser-window-focus",
+        "description": "Emitted when a browserWindow gets focused.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "window": {
+            "name": "window",
+            "type": "BrowserWindow"
+          }
+        }
+      },
+      "browser-window-created": {
+        "name": "browser-window-created",
+        "description": "Emitted when a new browserWindow is created.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "window": {
+            "name": "window",
+            "type": "BrowserWindow"
+          }
+        }
+      },
+      "web-contents-created": {
+        "name": "web-contents-created",
+        "description": "Emitted when a new webContents is created.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "webContents": {
+            "name": "webContents",
+            "type": "WebContents"
+          }
+        }
+      },
+      "certificate-error": {
+        "name": "certificate-error",
+        "description": "Emitted when failed to verify the certificate for url, to trust the certificate you should prevent the default behavior with event.preventDefault() and call callback(true).",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "webContents": {
+            "name": "webContents",
+            "type": "WebContents"
+          },
+          "url": {
+            "name": "url",
+            "type": "URL"
+          },
+          "error": {
+            "name": "error",
+            "type": "String",
+            "description": "The error code"
+          },
+          "certificate": {
+            "name": "certificate",
+            "type": "Object",
+            "properties": {
+              "data": {
+                "name": "data",
+                "type": "String",
+                "description": "PEM encoded data"
+              },
+              "issuerName": {
+                "name": "issuerName",
+                "type": "String",
+                "description": "Issuer's Common Name"
+              },
+              "subjectName": {
+                "name": "subjectName",
+                "type": "String",
+                "description": "Subject's Common Name"
+              },
+              "serialNumber": {
+                "name": "serialNumber",
+                "type": "String",
+                "description": "Hex value represented string"
+              },
+              "validStart": {
+                "name": "validStart",
+                "type": "Integer",
+                "description": "Start date of the certificate being valid in seconds"
+              },
+              "validExpiry": {
+                "name": "validExpiry",
+                "type": "Integer",
+                "description": "End date of the certificate being valid in seconds"
+              },
+              "fingerprint": {
+                "name": "fingerprint",
+                "type": "String",
+                "description": "Fingerprint of the certificate"
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "select-client-certificate": {
+        "name": "select-client-certificate",
+        "description": "Emitted when a client certificate is requested. The url corresponds to the navigation entry requesting the client certificate and callback needs to be called with an entry filtered from the list. Using event.preventDefault() prevents the application from using the first certificate from the store.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "webContents": {
+            "name": "webContents",
+            "type": "WebContents"
+          },
+          "url": {
+            "name": "url",
+            "type": "URL"
+          },
+          "certificateList": {
+            "name": "certificateList",
+            "type": "Certificate[]"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "login": {
+        "name": "login",
+        "description": "Emitted when webContents wants to do basic auth. The default behavior is to cancel all authentications, to override this you should prevent the default behavior with event.preventDefault() and call callback(username, password) with the credentials.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "webContents": {
+            "name": "webContents",
+            "type": "WebContents"
+          },
+          "request": {
+            "name": "request",
+            "type": "Object",
+            "properties": {
+              "method": {
+                "name": "method",
+                "type": "String",
+                "description": ""
+              },
+              "url": {
+                "name": "url",
+                "type": "URL",
+                "description": ""
+              },
+              "referrer": {
+                "name": "referrer",
+                "type": "URL",
+                "description": ""
+              }
+            }
+          },
+          "authInfo": {
+            "name": "authInfo",
+            "type": "Object",
+            "properties": {
+              "isProxy": {
+                "name": "isProxy",
+                "type": "Boolean",
+                "description": ""
+              },
+              "scheme": {
+                "name": "scheme",
+                "type": "String",
+                "description": ""
+              },
+              "host": {
+                "name": "host",
+                "type": "String",
+                "description": ""
+              },
+              "port": {
+                "name": "port",
+                "type": "Integer",
+                "description": ""
+              },
+              "realm": {
+                "name": "realm",
+                "type": "String",
+                "description": ""
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "gpu-process-crashed": {
+        "name": "gpu-process-crashed",
+        "description": "Emitted when the gpu process crashes or is killed.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "killed": {
+            "name": "killed",
+            "type": "Boolean"
+          }
+        }
+      },
+      "accessibility-support-changed": {
+        "name": "accessibility-support-changed",
+        "description": "Emitted when Chrome's accessibility support changes. This event fires when assistive technologies, such as screen readers, are enabled or disabled. See https://www.chromium.org/developers/design-documents/accessibility for more details.",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "accessibilitySupportEnabled": {
+            "name": "accessibilitySupportEnabled",
+            "type": "Boolean",
+            "description": "`true` when Chrome's accessibility support is enabled, `false` otherwise."
+          }
+        }
+      }
+    }
+  },
+  "autoUpdater": {
+    "name": "autoUpdater",
+    "description": "Enable apps to automatically update themselves.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Module",
+    "slug": "auto-updater",
+    "websiteUrl": "http://electron.atom.io/docs/api/auto-updater",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/auto-updater.md",
+    "methods": {
+      "setFeedURL": {
+        "name": "setFeedURL",
+        "signature": "(url[, requestHeaders])",
+        "description": "Sets the url and initialize the auto updater.",
+        "parameters": {
+          "url": {
+            "name": "url",
+            "type": "String"
+          },
+          "requestHeaders": {
+            "name": "requestHeaders",
+            "type": "Object",
+            "description": "- HTTP request headers."
+          }
+        }
+      },
+      "getFeedURL": {
+        "name": "getFeedURL",
+        "signature": "()",
+        "returns": {
+          "type": "String",
+          "description": "The current update feed URL."
+        }
+      },
+      "checkForUpdates": {
+        "name": "checkForUpdates",
+        "signature": "()",
+        "description": "Asks the server whether there is an update. You must call setFeedURL before using this API."
+      },
+      "quitAndInstall": {
+        "name": "quitAndInstall",
+        "signature": "()",
+        "description": "Restarts the app and installs the update after it has been downloaded. It should only be called after update-downloaded has been emitted."
+      }
+    },
+    "events": {
+      "error": {
+        "name": "error",
+        "description": "Emitted when there is an error while updating.",
+        "returns": {
+          "error": {
+            "name": "error",
+            "type": "Error"
+          }
+        }
+      },
+      "checking-for-update": {
+        "name": "checking-for-update",
+        "description": "Emitted when checking if an update has started."
+      },
+      "update-available": {
+        "name": "update-available",
+        "description": "Emitted when there is an available update. The update is downloaded automatically."
+      },
+      "update-not-available": {
+        "name": "update-not-available",
+        "description": "Emitted when there is no available update."
+      },
+      "update-downloaded": {
+        "name": "update-downloaded",
+        "description": "Emitted when an update has been downloaded. On Windows only releaseName is available.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "releaseNotes": {
+            "name": "releaseNotes",
+            "type": "String"
+          },
+          "releaseName": {
+            "name": "releaseName",
+            "type": "String"
+          },
+          "releaseDate": {
+            "name": "releaseDate",
+            "type": "Date"
+          },
+          "updateURL": {
+            "name": "updateURL",
+            "type": "String"
+          }
+        }
+      }
+    }
+  },
+  "BrowserWindow": {
+    "name": "BrowserWindow",
+    "description": "Create and control browser windows.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Class",
+    "slug": "browser-window",
+    "websiteUrl": "http://electron.atom.io/docs/api/browser-window",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/browser-window.md",
+    "staticMethods": {
+      "getAllWindows": {
+        "name": "getAllWindows",
+        "signature": "()",
+        "returns": {
+          "type": "BrowserWindow[]",
+          "description": "An array of all opened browser windows."
+        }
+      },
+      "getFocusedWindow": {
+        "name": "getFocusedWindow",
+        "signature": "()",
+        "returns": {
+          "type": "BrowserWindow",
+          "description": "The window that is focused in this application, otherwise returns null."
+        }
+      },
+      "fromWebContents": {
+        "name": "fromWebContents",
+        "signature": "(webContents)",
+        "parameters": {
+          "webContents": {
+            "name": "webContents",
+            "type": "WebContents"
+          }
+        },
+        "returns": {
+          "type": "BrowserWindow",
+          "description": "The window that owns the given webContents."
+        }
+      },
+      "fromId": {
+        "name": "fromId",
+        "signature": "(id)",
+        "parameters": {
+          "id": {
+            "name": "id",
+            "type": "Integer"
+          }
+        },
+        "returns": {
+          "type": "BrowserWindow",
+          "description": "The window with the given id."
+        }
+      },
+      "addDevToolsExtension": {
+        "name": "addDevToolsExtension",
+        "signature": "(path)",
+        "description": "Adds DevTools extension located at path, and returns extension's name. The extension will be remembered so you only need to call this API once, this API is not for programming use. If you try to add an extension that has already been loaded, this method will not return and instead log a warning to the console. The method will also not return if the extension's manifest is missing or incomplete. Note: This API cannot be called before the ready event of the app module is emitted.",
+        "parameters": {
+          "path": {
+            "name": "path",
+            "type": "String"
+          }
+        }
+      },
+      "removeDevToolsExtension": {
+        "name": "removeDevToolsExtension",
+        "signature": "(name)",
+        "description": "Remove a DevTools extension by name. Note: This API cannot be called before the ready event of the app module is emitted.",
+        "parameters": {
+          "name": {
+            "name": "name",
+            "type": "String"
+          }
+        }
+      },
+      "getDevToolsExtensions": {
+        "name": "getDevToolsExtensions",
+        "signature": "()",
+        "description": "To check if a DevTools extension is installed you can run the following: Note: This API cannot be called before the ready event of the app module is emitted.",
+        "returns": {
+          "type": "Object",
+          "description": "The keys are the extension names and each value is an Object containing name and version properties."
+        }
+      }
+    },
+    "constructorMethod": {
+      "signature": "([options])",
+      "parameters": [
+        {
+          "name": "options",
+          "type": "Object",
+          "properties": [
+            {
+              "name": "width",
+              "type": "Integer",
+              "description": "Window's width in pixels. Default is ."
+            },
+            {
+              "name": "height",
+              "type": "Integer",
+              "description": "Window's height in pixels. Default is ."
+            },
+            {
+              "name": "x",
+              "type": "Integer",
+              "description": "( if y is used) - Window's left offset from screen. Default is to center the window."
+            },
+            {
+              "name": "y",
+              "type": "Integer",
+              "description": "( if x is used) - Window's top offset from screen. Default is to center the window."
+            },
+            {
+              "name": "useContentSize",
+              "type": "Boolean",
+              "description": "The and would be used as web page's size, which means the actual window's size will include window frame's size and be slightly larger. Default is ."
+            },
+            {
+              "name": "center",
+              "type": "Boolean",
+              "description": "Show window in the center of the screen."
+            },
+            {
+              "name": "minWidth",
+              "type": "Integer",
+              "description": "Window's minimum width. Default is ."
+            },
+            {
+              "name": "minHeight",
+              "type": "Integer",
+              "description": "Window's minimum height. Default is ."
+            },
+            {
+              "name": "maxWidth",
+              "type": "Integer",
+              "description": "Window's maximum width. Default is no limit."
+            },
+            {
+              "name": "maxHeight",
+              "type": "Integer",
+              "description": "Window's maximum height. Default is no limit."
+            },
+            {
+              "name": "resizable",
+              "type": "Boolean",
+              "description": "Whether window is resizable. Default is ."
+            },
+            {
+              "name": "movable",
+              "type": "Boolean",
+              "description": "Whether window is movable. This is not implemented on Linux. Default is ."
+            },
+            {
+              "name": "minimizable",
+              "type": "Boolean",
+              "description": "Whether window is minimizable. This is not implemented on Linux. Default is ."
+            },
+            {
+              "name": "maximizable",
+              "type": "Boolean",
+              "description": "Whether window is maximizable. This is not implemented on Linux. Default is ."
+            },
+            {
+              "name": "closable",
+              "type": "Boolean",
+              "description": "Whether window is closable. This is not implemented on Linux. Default is ."
+            },
+            {
+              "name": "focusable",
+              "type": "Boolean",
+              "description": "Whether the window can be focused. Default is . On Windows setting also implies setting . On Linux setting makes the window stop interacting with wm, so the window will always stay on top in all workspaces."
+            },
+            {
+              "name": "alwaysOnTop",
+              "type": "Boolean",
+              "description": "Whether the window should always stay on top of other windows. Default is ."
+            },
+            {
+              "name": "fullscreen",
+              "type": "Boolean",
+              "description": "Whether the window should show in fullscreen. When explicitly set to the fullscreen button will be hidden or disabled on macOS. Default is ."
+            },
+            {
+              "name": "fullscreenable",
+              "type": "Boolean",
+              "description": "Whether the window can be put into fullscreen mode. On macOS, also whether the maximize/zoom button should toggle full screen mode or maximize window. Default is ."
+            },
+            {
+              "name": "skipTaskbar",
+              "type": "Boolean",
+              "description": "Whether to show the window in taskbar. Default is ."
+            },
+            {
+              "name": "kiosk",
+              "type": "Boolean",
+              "description": "The kiosk mode. Default is ."
+            },
+            {
+              "name": "title",
+              "type": "String",
+              "description": "Default window title. Default is ."
+            },
+            {
+              "name": "icon",
+              "type": "NativeImage",
+              "description": "The window icon. On Windows it is recommended to use icons to get best visual effects, you can also leave it undefined so the executable's icon will be used."
+            },
+            {
+              "name": "show",
+              "type": "Boolean",
+              "description": "Whether window should be shown when created. Default is ."
+            },
+            {
+              "name": "frame",
+              "type": "Boolean",
+              "description": "Specify to create a . Default is ."
+            },
+            {
+              "name": "parent",
+              "type": "BrowserWindow",
+              "description": "Specify parent window. Default is ."
+            },
+            {
+              "name": "modal",
+              "type": "Boolean",
+              "description": "Whether this is a modal window. This only works when the window is a child window. Default is ."
+            },
+            {
+              "name": "acceptFirstMouse",
+              "type": "Boolean",
+              "description": "Whether the web view accepts a single mouse-down event that simultaneously activates the window. Default is ."
+            },
+            {
+              "name": "disableAutoHideCursor",
+              "type": "Boolean",
+              "description": "Whether to hide cursor when typing. Default is ."
+            },
+            {
+              "name": "autoHideMenuBar",
+              "type": "Boolean",
+              "description": "Auto hide the menu bar unless the key is pressed. Default is ."
+            },
+            {
+              "name": "enableLargerThanScreen",
+              "type": "Boolean",
+              "description": "Enable the window to be resized larger than screen. Default is ."
+            },
+            {
+              "name": "backgroundColor",
+              "type": "String",
+              "description": "Window's background color as Hexadecimal value, like or or (alpha is supported). Default is (white)."
+            },
+            {
+              "name": "hasShadow",
+              "type": "Boolean",
+              "description": "Whether window should have a shadow. This is only implemented on macOS. Default is ."
+            },
+            {
+              "name": "darkTheme",
+              "type": "Boolean",
+              "description": "Forces using dark theme for the window, only works on some GTK+3 desktop environments. Default is ."
+            },
+            {
+              "name": "transparent",
+              "type": "Boolean",
+              "description": "Makes the window . Default is ."
+            },
+            {
+              "name": "type",
+              "type": "String",
+              "description": "The type of window, default is normal window. See more about this below."
+            },
+            {
+              "name": "titleBarStyle",
+              "type": "String",
+              "description": "The style of window title bar. See more about this below."
+            },
+            {
+              "name": "thickFrame",
+              "type": "Boolean",
+              "description": "Use style for frameless windows on Windows, which adds standard window frame. Setting it to will remove window shadow and window animations. Default is ."
+            },
+            {
+              "name": "webPreferences",
+              "type": "Object",
+              "description": "Settings of web page's features. See more about this below.",
+              "properties": []
+            }
+          ]
+        }
+      ]
+    },
+    "instanceName": "win",
+    "instanceMethods": {
+      "destroy": {
+        "name": "destroy",
+        "signature": "()",
+        "description": "Force closing the window, the unload and beforeunload event won't be emitted for the web page, and close event will also not be emitted for this window, but it guarantees the closed event will be emitted."
+      },
+      "close": {
+        "name": "close",
+        "signature": "()",
+        "description": "Try to close the window. This has the same effect as a user manually clicking the close button of the window. The web page may cancel the close though. See the close event."
+      },
+      "focus": {
+        "name": "focus",
+        "signature": "()",
+        "description": "Focuses on the window."
+      },
+      "blur": {
+        "name": "blur",
+        "signature": "()",
+        "description": "Removes focus from the window."
+      },
+      "isFocused": {
+        "name": "isFocused",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window is focused."
+        }
+      },
+      "isDestroyed": {
+        "name": "isDestroyed",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window is destroyed."
+        }
+      },
+      "show": {
+        "name": "show",
+        "signature": "()",
+        "description": "Shows and gives focus to the window."
+      },
+      "showInactive": {
+        "name": "showInactive",
+        "signature": "()",
+        "description": "Shows the window but doesn't focus on it."
+      },
+      "hide": {
+        "name": "hide",
+        "signature": "()",
+        "description": "Hides the window."
+      },
+      "isVisible": {
+        "name": "isVisible",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window is visible to the user."
+        }
+      },
+      "isModal": {
+        "name": "isModal",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether current window is a modal window."
+        }
+      },
+      "maximize": {
+        "name": "maximize",
+        "signature": "()",
+        "description": "Maximizes the window."
+      },
+      "unmaximize": {
+        "name": "unmaximize",
+        "signature": "()",
+        "description": "Unmaximizes the window."
+      },
+      "isMaximized": {
+        "name": "isMaximized",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window is maximized."
+        }
+      },
+      "minimize": {
+        "name": "minimize",
+        "signature": "()",
+        "description": "Minimizes the window. On some platforms the minimized window will be shown in the Dock."
+      },
+      "restore": {
+        "name": "restore",
+        "signature": "()",
+        "description": "Restores the window from minimized state to its previous state."
+      },
+      "isMinimized": {
+        "name": "isMinimized",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window is minimized."
+        }
+      },
+      "setFullScreen": {
+        "name": "setFullScreen",
+        "signature": "(flag)",
+        "description": "Sets whether the window should be in fullscreen mode.",
+        "parameters": {
+          "flag": {
+            "name": "flag",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isFullScreen": {
+        "name": "isFullScreen",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window is in fullscreen mode."
+        }
+      },
+      "setAspectRatio": {
+        "name": "setAspectRatio",
+        "signature": "(aspectRatio[, extraSize])",
+        "platforms": {},
+        "description": "This will make a window maintain an aspect ratio. The extra size allows a developer to have space, specified in pixels, not included within the aspect ratio calculations. This API already takes into account the difference between a window's size and its content size. Consider a normal window with an HD video player and associated controls. Perhaps there are 15 pixels of controls on the left edge, 25 pixels of controls on the right edge and 50 pixels of controls below the player. In order to maintain a 16:9 aspect ratio (standard aspect ratio for HD @1920x1080) within the player itself we would call this function with arguments of 16/9 and [ 40, 50 ]. The second argument doesn't care where the extra width and height are within the content view--only that they exist. Just sum any extra width and height areas you have within the overall content view.",
+        "parameters": {
+          "aspectRatio": {
+            "name": "aspectRatio",
+            "type": "Float",
+            "description": "The aspect ratio to maintain for some portion of the content view."
+          },
+          "extraSize": {
+            "name": "extraSize",
+            "type": "Object",
+            "description": "(optional) - The extra size not to be included while maintaining the aspect ratio.",
+            "properties": {
+              "width": {
+                "name": "width",
+                "type": "Integer",
+                "description": ""
+              },
+              "height": {
+                "name": "height",
+                "type": "Integer",
+                "description": ""
+              }
+            }
+          }
+        }
+      },
+      "setBounds": {
+        "name": "setBounds",
+        "signature": "(bounds[, animate])",
+        "description": "Resizes and moves the window to the supplied bounds",
+        "parameters": {
+          "bounds": {
+            "name": "bounds",
+            "type": "Rectangle"
+          },
+          "animate": {
+            "name": "animate",
+            "type": "Boolean",
+            "description": "(optional)"
+          }
+        }
+      },
+      "getBounds": {
+        "name": "getBounds",
+        "signature": "()",
+        "returns": {
+          "type": "Rectangle"
+        }
+      },
+      "setContentBounds": {
+        "name": "setContentBounds",
+        "signature": "(bounds[, animate])",
+        "description": "Resizes and moves the window's client area (e.g. the web page) to the supplied bounds.",
+        "parameters": {
+          "bounds": {
+            "name": "bounds",
+            "type": "Rectangle"
+          },
+          "animate": {
+            "name": "animate",
+            "type": "Boolean",
+            "description": "(optional)"
+          }
+        }
+      },
+      "getContentBounds": {
+        "name": "getContentBounds",
+        "signature": "()",
+        "returns": {
+          "type": "Rectangle"
+        }
+      },
+      "setSize": {
+        "name": "setSize",
+        "signature": "(width, height[, animate])",
+        "description": "Resizes the window to width and height.",
+        "parameters": {
+          "width": {
+            "name": "width",
+            "type": "Integer"
+          },
+          "height": {
+            "name": "height",
+            "type": "Integer"
+          },
+          "animate": {
+            "name": "animate",
+            "type": "Boolean",
+            "description": "(optional)"
+          }
+        }
+      },
+      "getSize": {
+        "name": "getSize",
+        "signature": "()",
+        "returns": {
+          "type": "Integer[]",
+          "description": "Contains the window's width and height."
+        }
+      },
+      "setContentSize": {
+        "name": "setContentSize",
+        "signature": "(width, height[, animate])",
+        "description": "Resizes the window's client area (e.g. the web page) to width and height.",
+        "parameters": {
+          "width": {
+            "name": "width",
+            "type": "Integer"
+          },
+          "height": {
+            "name": "height",
+            "type": "Integer"
+          },
+          "animate": {
+            "name": "animate",
+            "type": "Boolean",
+            "description": "(optional)"
+          }
+        }
+      },
+      "getContentSize": {
+        "name": "getContentSize",
+        "signature": "()",
+        "returns": {
+          "type": "Integer[]",
+          "description": "Contains the window's client area's width and height."
+        }
+      },
+      "setMinimumSize": {
+        "name": "setMinimumSize",
+        "signature": "(width, height)",
+        "description": "Sets the minimum size of window to width and height.",
+        "parameters": {
+          "width": {
+            "name": "width",
+            "type": "Integer"
+          },
+          "height": {
+            "name": "height",
+            "type": "Integer"
+          }
+        }
+      },
+      "getMinimumSize": {
+        "name": "getMinimumSize",
+        "signature": "()",
+        "returns": {
+          "type": "Integer[]",
+          "description": "Contains the window's minimum width and height."
+        }
+      },
+      "setMaximumSize": {
+        "name": "setMaximumSize",
+        "signature": "(width, height)",
+        "description": "Sets the maximum size of window to width and height.",
+        "parameters": {
+          "width": {
+            "name": "width",
+            "type": "Integer"
+          },
+          "height": {
+            "name": "height",
+            "type": "Integer"
+          }
+        }
+      },
+      "getMaximumSize": {
+        "name": "getMaximumSize",
+        "signature": "()",
+        "returns": {
+          "type": "Integer[]",
+          "description": "Contains the window's maximum width and height."
+        }
+      },
+      "setResizable": {
+        "name": "setResizable",
+        "signature": "(resizable)",
+        "description": "Sets whether the window can be manually resized by user.",
+        "parameters": {
+          "resizable": {
+            "name": "resizable",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isResizable": {
+        "name": "isResizable",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window can be manually resized by user."
+        }
+      },
+      "setMovable": {
+        "name": "setMovable",
+        "signature": "(movable)",
+        "platforms": {},
+        "description": "Sets whether the window can be moved by user. On Linux does nothing.",
+        "parameters": {
+          "movable": {
+            "name": "movable",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isMovable": {
+        "name": "isMovable",
+        "signature": "()",
+        "platforms": {},
+        "description": "On Linux always returns true.",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window can be moved by user."
+        }
+      },
+      "setMinimizable": {
+        "name": "setMinimizable",
+        "signature": "(minimizable)",
+        "platforms": {},
+        "description": "Sets whether the window can be manually minimized by user. On Linux does nothing.",
+        "parameters": {
+          "minimizable": {
+            "name": "minimizable",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isMinimizable": {
+        "name": "isMinimizable",
+        "signature": "()",
+        "platforms": {},
+        "description": "On Linux always returns true.",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window can be manually minimized by user"
+        }
+      },
+      "setMaximizable": {
+        "name": "setMaximizable",
+        "signature": "(maximizable)",
+        "platforms": {},
+        "description": "Sets whether the window can be manually maximized by user. On Linux does nothing.",
+        "parameters": {
+          "maximizable": {
+            "name": "maximizable",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isMaximizable": {
+        "name": "isMaximizable",
+        "signature": "()",
+        "platforms": {},
+        "description": "On Linux always returns true.",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window can be manually maximized by user."
+        }
+      },
+      "setFullScreenable": {
+        "name": "setFullScreenable",
+        "signature": "(fullscreenable)",
+        "description": "Sets whether the maximize/zoom window button toggles fullscreen mode or maximizes the window.",
+        "parameters": {
+          "fullscreenable": {
+            "name": "fullscreenable",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isFullScreenable": {
+        "name": "isFullScreenable",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the maximize/zoom window button toggles fullscreen mode or maximizes the window."
+        }
+      },
+      "setClosable": {
+        "name": "setClosable",
+        "signature": "(closable)",
+        "platforms": {},
+        "description": "Sets whether the window can be manually closed by user. On Linux does nothing.",
+        "parameters": {
+          "closable": {
+            "name": "closable",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isClosable": {
+        "name": "isClosable",
+        "signature": "()",
+        "platforms": {},
+        "description": "On Linux always returns true.",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window can be manually closed by user."
+        }
+      },
+      "setAlwaysOnTop": {
+        "name": "setAlwaysOnTop",
+        "signature": "(flag[, level])",
+        "description": "Sets whether the window should show always on top of other windows. After setting this, the window is still a normal window, not a toolbox window which can not be focused on.",
+        "parameters": {
+          "flag": {
+            "name": "flag",
+            "type": "Boolean"
+          },
+          "level": {
+            "name": "level",
+            "type": "String",
+            "description": "(optional) - Values include `normal`, `floating`, `torn-off-menu`, `modal-panel`, `main-menu`, `status`, `pop-up-menu`, `screen-saver`, and `dock`. The default is `floating`. See the for more details."
+          }
+        }
+      },
+      "isAlwaysOnTop": {
+        "name": "isAlwaysOnTop",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window is always on top of other windows."
+        }
+      },
+      "center": {
+        "name": "center",
+        "signature": "()",
+        "description": "Moves window to the center of the screen."
+      },
+      "setPosition": {
+        "name": "setPosition",
+        "signature": "(x, y[, animate])",
+        "description": "Moves window to x and y.",
+        "parameters": {
+          "x": {
+            "name": "x",
+            "type": "Integer"
+          },
+          "y": {
+            "name": "y",
+            "type": "Integer"
+          },
+          "animate": {
+            "name": "animate",
+            "type": "Boolean",
+            "description": "(optional)"
+          }
+        }
+      },
+      "getPosition": {
+        "name": "getPosition",
+        "signature": "()",
+        "returns": {
+          "type": "Integer[]",
+          "description": "Contains the window's current position."
+        }
+      },
+      "setTitle": {
+        "name": "setTitle",
+        "signature": "(title)",
+        "description": "Changes the title of native window to title.",
+        "parameters": {
+          "title": {
+            "name": "title",
+            "type": "String"
+          }
+        }
+      },
+      "getTitle": {
+        "name": "getTitle",
+        "signature": "()",
+        "description": "Note: The title of web page can be different from the title of the native window.",
+        "returns": {
+          "type": "String",
+          "description": "The title of the native window."
+        }
+      },
+      "setSheetOffset": {
+        "name": "setSheetOffset",
+        "signature": "(offsetY[, offsetX])",
+        "platforms": {},
+        "description": "Changes the attachment point for sheets on macOS. By default, sheets are attached just below the window frame, but you may want to display them beneath a HTML-rendered toolbar. For example:",
+        "parameters": {
+          "offsetY": {
+            "name": "offsetY",
+            "type": "Float"
+          },
+          "offsetX": {
+            "name": "offsetX",
+            "type": "Float",
+            "description": "(optional)"
+          }
+        }
+      },
+      "flashFrame": {
+        "name": "flashFrame",
+        "signature": "(flag)",
+        "description": "Starts or stops flashing the window to attract user's attention.",
+        "parameters": {
+          "flag": {
+            "name": "flag",
+            "type": "Boolean"
+          }
+        }
+      },
+      "setSkipTaskbar": {
+        "name": "setSkipTaskbar",
+        "signature": "(skip)",
+        "description": "Makes the window not show in the taskbar.",
+        "parameters": {
+          "skip": {
+            "name": "skip",
+            "type": "Boolean"
+          }
+        }
+      },
+      "setKiosk": {
+        "name": "setKiosk",
+        "signature": "(flag)",
+        "description": "Enters or leaves the kiosk mode.",
+        "parameters": {
+          "flag": {
+            "name": "flag",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isKiosk": {
+        "name": "isKiosk",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window is in kiosk mode."
+        }
+      },
+      "getNativeWindowHandle": {
+        "name": "getNativeWindowHandle",
+        "signature": "()",
+        "description": "The native type of the handle is HWND on Windows, NSView* on macOS, and Window (unsigned long) on Linux.",
+        "returns": {
+          "type": "Buffer",
+          "description": "The platform-specific handle of the window."
+        }
+      },
+      "hookWindowMessage": {
+        "name": "hookWindowMessage",
+        "signature": "(message, callback)",
+        "platforms": {},
+        "description": "Hooks a windows message. The callback is called when the message is received in the WndProc.",
+        "parameters": {
+          "message": {
+            "name": "message",
+            "type": "Integer"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "isWindowMessageHooked": {
+        "name": "isWindowMessageHooked",
+        "signature": "(message)",
+        "platforms": {},
+        "parameters": {
+          "message": {
+            "name": "message",
+            "type": "Integer"
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "true or false depending on whether the message is hooked."
+        }
+      },
+      "unhookWindowMessage": {
+        "name": "unhookWindowMessage",
+        "signature": "(message)",
+        "platforms": {},
+        "description": "Unhook the window message.",
+        "parameters": {
+          "message": {
+            "name": "message",
+            "type": "Integer"
+          }
+        }
+      },
+      "unhookAllWindowMessages": {
+        "name": "unhookAllWindowMessages",
+        "signature": "()",
+        "platforms": {},
+        "description": "Unhooks all of the window messages."
+      },
+      "setRepresentedFilename": {
+        "name": "setRepresentedFilename",
+        "signature": "(filename)",
+        "platforms": {},
+        "description": "Sets the pathname of the file the window represents, and the icon of the file will show in window's title bar.",
+        "parameters": {
+          "filename": {
+            "name": "filename",
+            "type": "String"
+          }
+        }
+      },
+      "getRepresentedFilename": {
+        "name": "getRepresentedFilename",
+        "signature": "()",
+        "platforms": {},
+        "returns": {
+          "type": "String",
+          "description": "The pathname of the file the window represents."
+        }
+      },
+      "setDocumentEdited": {
+        "name": "setDocumentEdited",
+        "signature": "(edited)",
+        "platforms": {},
+        "description": "Specifies whether the window’s document has been edited, and the icon in title bar will become gray when set to true.",
+        "parameters": {
+          "edited": {
+            "name": "edited",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isDocumentEdited": {
+        "name": "isDocumentEdited",
+        "signature": "()",
+        "platforms": {},
+        "description": "Whether Boolean - Whether the window's document has been edited."
+      },
+      "focusOnWebView": {
+        "name": "focusOnWebView",
+        "signature": "()"
+      },
+      "blurWebView": {
+        "name": "blurWebView",
+        "signature": "()"
+      },
+      "capturePage": {
+        "name": "capturePage",
+        "signature": "([rect, ]callback)",
+        "description": "Same as webContents.capturePage([rect, ]callback).",
+        "parameters": {
+          "rect": {
+            "name": "rect",
+            "type": "Rectangle",
+            "description": "(optional) - The bounds to capture"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "loadURL": {
+        "name": "loadURL",
+        "signature": "(url[, options])",
+        "description": "Same as webContents.loadURL(url[, options]). The url can be a remote address (e.g. http://) or a path to a local HTML file using the file:// protocol. To ensure that file URLs are properly formatted, it is recommended to use Node's url.format method:",
+        "parameters": {
+          "url": {
+            "name": "url",
+            "type": "URL"
+          },
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "description": "(optional)",
+            "properties": {
+              "httpReferrer": {
+                "name": "httpReferrer",
+                "type": "String",
+                "description": "A HTTP Referrer url."
+              },
+              "userAgent": {
+                "name": "userAgent",
+                "type": "String",
+                "description": "A user agent originating the request."
+              },
+              "extraHeaders": {
+                "name": "extraHeaders",
+                "type": "String",
+                "description": "Extra headers separated by \"\\n\""
+              }
+            }
+          }
+        }
+      },
+      "reload": {
+        "name": "reload",
+        "signature": "()",
+        "description": "Same as webContents.reload."
+      },
+      "setMenu": {
+        "name": "setMenu",
+        "signature": "(menu)",
+        "platforms": {},
+        "description": "Sets the menu as the window's menu bar, setting it to null will remove the menu bar.",
+        "parameters": {
+          "menu": {
+            "name": "menu",
+            "type": "Menu"
+          }
+        }
+      },
+      "setProgressBar": {
+        "name": "setProgressBar",
+        "signature": "(progress[, options])",
+        "description": "Sets progress value in progress bar. Valid range is [0, 1.0]. Remove progress bar when progress < 0; Change to indeterminate mode when progress > 1. On Linux platform, only supports Unity desktop environment, you need to specify the *.desktop file name to desktopName field in package.json. By default, it will assume app.getName().desktop. On Windows, a mode can be passed. Accepted values are none, normal, indeterminate, error, and paused. If you call setProgressBar without a mode set (but with a value within the valid range), normal will be assumed.",
+        "parameters": {
+          "progress": {
+            "name": "progress",
+            "type": "Double"
+          },
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "description": "(optional)",
+            "properties": {
+              "mode": {
+                "name": "mode",
+                "type": "String",
+                "description": "- Mode for the progress bar (, , , , or )"
+              }
+            }
+          }
+        }
+      },
+      "setOverlayIcon": {
+        "name": "setOverlayIcon",
+        "signature": "(overlay, description)",
+        "platforms": {},
+        "description": "Sets a 16 x 16 pixel overlay onto the current taskbar icon, usually used to convey some sort of application status or to passively notify the user.",
+        "parameters": {
+          "overlay": {
+            "name": "overlay",
+            "type": "NativeImage",
+            "description": "the icon to display on the bottom right corner of the taskbar icon. If this parameter is `null`, the overlay is cleared"
+          },
+          "description": {
+            "name": "description",
+            "type": "String",
+            "description": "a description that will be provided to Accessibility screen readers"
+          }
+        }
+      },
+      "setHasShadow": {
+        "name": "setHasShadow",
+        "signature": "(hasShadow)",
+        "platforms": {},
+        "description": "Sets whether the window should have a shadow. On Windows and Linux does nothing.",
+        "parameters": {
+          "hasShadow": {
+            "name": "hasShadow",
+            "type": "Boolean"
+          }
+        }
+      },
+      "hasShadow": {
+        "name": "hasShadow",
+        "signature": "()",
+        "platforms": {},
+        "description": "On Windows and Linux always returns true.",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window has a shadow."
+        }
+      },
+      "setThumbarButtons": {
+        "name": "setThumbarButtons",
+        "signature": "(buttons)",
+        "platforms": {},
+        "description": "Add a thumbnail toolbar with a specified set of buttons to the thumbnail image of a window in a taskbar button layout. Returns a Boolean object indicates whether the thumbnail has been added successfully. The number of buttons in thumbnail toolbar should be no greater than 7 due to the limited room. Once you setup the thumbnail toolbar, the toolbar cannot be removed due to the platform's limitation. But you can call the API with an empty array to clean the buttons. The buttons is an array of Button objects: The flags is an array that can include following Strings:",
+        "parameters": {
+          "buttons": {
+            "name": "buttons",
+            "type": "ThumbarButton[]"
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the buttons were added successfully"
+        }
+      },
+      "setThumbnailClip": {
+        "name": "setThumbnailClip",
+        "signature": "(region)",
+        "platforms": {},
+        "description": "Sets the region of the window to show as the thumbnail image displayed when hovering over the window in the taskbar. You can reset the thumbnail to be the entire window by specifying an empty region: {x: 0, y: 0, width: 0, height: 0}.",
+        "parameters": {
+          "region": {
+            "name": "region",
+            "type": "Rectangle",
+            "description": "Region of the window"
+          }
+        }
+      },
+      "setThumbnailToolTip": {
+        "name": "setThumbnailToolTip",
+        "signature": "(toolTip)",
+        "platforms": {},
+        "description": "Sets the toolTip that is displayed when hovering over the window thumbnail in the taskbar.",
+        "parameters": {
+          "toolTip": {
+            "name": "toolTip",
+            "type": "String"
+          }
+        }
+      },
+      "showDefinitionForSelection": {
+        "name": "showDefinitionForSelection",
+        "signature": "()",
+        "platforms": {},
+        "description": "Same as webContents.showDefinitionForSelection()."
+      },
+      "setIcon": {
+        "name": "setIcon",
+        "signature": "(icon)",
+        "platforms": {},
+        "description": "Changes window icon.",
+        "parameters": {
+          "icon": {
+            "name": "icon",
+            "type": "NativeImage"
+          }
+        }
+      },
+      "setAutoHideMenuBar": {
+        "name": "setAutoHideMenuBar",
+        "signature": "(hide)",
+        "description": "Sets whether the window menu bar should hide itself automatically. Once set the menu bar will only show when users press the single Alt key. If the menu bar is already visible, calling setAutoHideMenuBar(true) won't hide it immediately.",
+        "parameters": {
+          "hide": {
+            "name": "hide",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isMenuBarAutoHide": {
+        "name": "isMenuBarAutoHide",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether menu bar automatically hides itself."
+        }
+      },
+      "setMenuBarVisibility": {
+        "name": "setMenuBarVisibility",
+        "signature": "(visible)",
+        "description": "Sets whether the menu bar should be visible. If the menu bar is auto-hide, users can still bring up the menu bar by pressing the single Alt key.",
+        "parameters": {
+          "visible": {
+            "name": "visible",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isMenuBarVisible": {
+        "name": "isMenuBarVisible",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the menu bar is visible."
+        }
+      },
+      "setVisibleOnAllWorkspaces": {
+        "name": "setVisibleOnAllWorkspaces",
+        "signature": "(visible)",
+        "description": "Sets whether the window should be visible on all workspaces. Note: This API does nothing on Windows.",
+        "parameters": {
+          "visible": {
+            "name": "visible",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isVisibleOnAllWorkspaces": {
+        "name": "isVisibleOnAllWorkspaces",
+        "signature": "()",
+        "description": "Note: This API always returns false on Windows.",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the window is visible on all workspaces."
+        }
+      },
+      "setIgnoreMouseEvents": {
+        "name": "setIgnoreMouseEvents",
+        "signature": "(ignore)",
+        "description": "Makes the window ignore all mouse events. All mouse events happened in this window will be passed to the window below this window, but if this window has focus, it will still receive keyboard events.",
+        "parameters": {
+          "ignore": {
+            "name": "ignore",
+            "type": "Boolean"
+          }
+        }
+      },
+      "setContentProtection": {
+        "name": "setContentProtection",
+        "signature": "(enable)",
+        "platforms": {},
+        "description": "Prevents the window contents from being captured by other apps. On macOS it sets the NSWindow's sharingType to NSWindowSharingNone. On Windows it calls SetWindowDisplayAffinity with WDA_MONITOR.",
+        "parameters": {
+          "enable": {
+            "name": "enable",
+            "type": "Boolean"
+          }
+        }
+      },
+      "setFocusable": {
+        "name": "setFocusable",
+        "signature": "(focusable)",
+        "platforms": {},
+        "description": "Changes whether the window can be focused.",
+        "parameters": {
+          "focusable": {
+            "name": "focusable",
+            "type": "Boolean"
+          }
+        }
+      },
+      "setParentWindow": {
+        "name": "setParentWindow",
+        "signature": "(parent)",
+        "platforms": {},
+        "description": "Sets parent as current window's parent window, passing null will turn current window into a top-level window.",
+        "parameters": {
+          "parent": {
+            "name": "parent",
+            "type": "BrowserWindow"
+          }
+        }
+      },
+      "getParentWindow": {
+        "name": "getParentWindow",
+        "signature": "()",
+        "returns": {
+          "type": "BrowserWindow",
+          "description": "The parent window."
+        }
+      },
+      "getChildWindows": {
+        "name": "getChildWindows",
+        "signature": "()",
+        "returns": {
+          "type": "BrowserWindow[]",
+          "description": "All child windows."
+        }
+      }
+    },
+    "instanceProperties": {
+      "webContents": {
+        "name": "webContents",
+        "description": "A WebContents object this window owns. All web page related events and operations will be done via it. See the webContents documentation for its methods and events."
+      },
+      "id": {
+        "name": "id",
+        "description": "A Integer representing the unique ID of the window."
+      }
+    },
+    "instanceEvents": {
+      "page-title-updated": {
+        "name": "page-title-updated",
+        "description": "Emitted when the document changed its title, calling event.preventDefault() will prevent the native window's title from changing.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "title": {
+            "name": "title",
+            "type": "String"
+          }
+        }
+      },
+      "close": {
+        "name": "close",
+        "description": "Emitted when the window is going to be closed. It's emitted before the beforeunload and unload event of the DOM. Calling event.preventDefault() will cancel the close. Usually you would want to use the beforeunload handler to decide whether the window should be closed, which will also be called when the window is reloaded. In Electron, returning any value other than undefined would cancel the close. For example:",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          }
+        }
+      },
+      "closed": {
+        "name": "closed",
+        "description": "Emitted when the window is closed. After you have received this event you should remove the reference to the window and avoid using it any more."
+      },
+      "unresponsive": {
+        "name": "unresponsive",
+        "description": "Emitted when the web page becomes unresponsive."
+      },
+      "responsive": {
+        "name": "responsive",
+        "description": "Emitted when the unresponsive web page becomes responsive again."
+      },
+      "blur": {
+        "name": "blur",
+        "description": "Emitted when the window loses focus."
+      },
+      "focus": {
+        "name": "focus",
+        "description": "Emitted when the window gains focus."
+      },
+      "show": {
+        "name": "show",
+        "description": "Emitted when the window is shown."
+      },
+      "hide": {
+        "name": "hide",
+        "description": "Emitted when the window is hidden."
+      },
+      "ready-to-show": {
+        "name": "ready-to-show",
+        "description": "Emitted when the web page has been rendered and window can be displayed without a visual flash."
+      },
+      "maximize": {
+        "name": "maximize",
+        "description": "Emitted when window is maximized."
+      },
+      "unmaximize": {
+        "name": "unmaximize",
+        "description": "Emitted when the window exits from a maximized state."
+      },
+      "minimize": {
+        "name": "minimize",
+        "description": "Emitted when the window is minimized."
+      },
+      "restore": {
+        "name": "restore",
+        "description": "Emitted when the window is restored from a minimized state."
+      },
+      "resize": {
+        "name": "resize",
+        "description": "Emitted when the window is being resized."
+      },
+      "move": {
+        "name": "move",
+        "description": "Emitted when the window is being moved to a new position. Note: On macOS this event is just an alias of moved."
+      },
+      "moved": {
+        "name": "moved",
+        "description": "Emitted once when the window is moved to a new position.",
+        "platforms": {}
+      },
+      "enter-full-screen": {
+        "name": "enter-full-screen",
+        "description": "Emitted when the window enters a full-screen state."
+      },
+      "leave-full-screen": {
+        "name": "leave-full-screen",
+        "description": "Emitted when the window leaves a full-screen state."
+      },
+      "enter-html-full-screen": {
+        "name": "enter-html-full-screen",
+        "description": "Emitted when the window enters a full-screen state triggered by HTML API."
+      },
+      "leave-html-full-screen": {
+        "name": "leave-html-full-screen",
+        "description": "Emitted when the window leaves a full-screen state triggered by HTML API."
+      },
+      "app-command": {
+        "name": "app-command",
+        "description": "Emitted when an App Command is invoked. These are typically related to keyboard media keys or browser commands, as well as the \"Back\" button built into some mice on Windows. Commands are lowercased, underscores are replaced with hyphens, and the APPCOMMAND_ prefix is stripped off. e.g. APPCOMMAND_BROWSER_BACKWARD is emitted as browser-backward.",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "command": {
+            "name": "command",
+            "type": "String"
+          }
+        }
+      },
+      "scroll-touch-begin": {
+        "name": "scroll-touch-begin",
+        "description": "Emitted when scroll wheel event phase has begun.",
+        "platforms": {}
+      },
+      "scroll-touch-end": {
+        "name": "scroll-touch-end",
+        "description": "Emitted when scroll wheel event phase has ended.",
+        "platforms": {}
+      },
+      "scroll-touch-edge": {
+        "name": "scroll-touch-edge",
+        "description": "Emitted when scroll wheel event phase filed upon reaching the edge of element.",
+        "platforms": {}
+      },
+      "swipe": {
+        "name": "swipe",
+        "description": "Emitted on 3-finger swipe. Possible directions are up, right, down, left.",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "direction": {
+            "name": "direction",
+            "type": "String"
+          }
+        }
+      }
+    }
+  },
+  "contentTracing": {
+    "name": "contentTracing",
+    "description": "Collect tracing data from Chromium's content module for finding performance\nbottlenecks and slow operations.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Module",
+    "slug": "content-tracing",
+    "websiteUrl": "http://electron.atom.io/docs/api/content-tracing",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/content-tracing.md",
+    "methods": {
+      "getCategories": {
+        "name": "getCategories",
+        "signature": "(callback)",
+        "description": "Get a set of category groups. The category groups can change as new code paths are reached. Once all child processes have acknowledged the getCategories request the callback is invoked with an array of category groups.",
+        "parameters": {
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "startRecording": {
+        "name": "startRecording",
+        "signature": "(options, callback)",
+        "description": "Start recording on all processes. Recording begins immediately locally and asynchronously on child processes as soon as they receive the EnableRecording request. The callback will be called once all child processes have acknowledged the startRecording request. categoryFilter is a filter to control what category groups should be traced. A filter can have an optional - prefix to exclude category groups that contain a matching category. Having both included and excluded category patterns in the same list is not supported. Examples: traceOptions controls what kind of tracing is enabled, it is a comma-delimited list. Possible options are: The first 3 options are trace recoding modes and hence mutually exclusive. If more than one trace recording modes appear in the traceOptions string, the last one takes precedence. If none of the trace recording modes are specified, recording mode is record-until-full. The trace option will first be reset to the default option (record_mode set to record-until-full, enable_sampling and enable_systrace set to false) before options parsed from traceOptions are applied on it.",
+        "parameters": {
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "properties": {
+              "categoryFilter": {
+                "name": "categoryFilter",
+                "type": "String",
+                "description": ""
+              },
+              "traceOptions": {
+                "name": "traceOptions",
+                "type": "String",
+                "description": ""
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "stopRecording": {
+        "name": "stopRecording",
+        "signature": "(resultFilePath, callback)",
+        "description": "Stop recording on all processes. Child processes typically cache trace data and only rarely flush and send trace data back to the main process. This helps to minimize the runtime overhead of tracing since sending trace data over IPC can be an expensive operation. So, to end tracing, we must asynchronously ask all child processes to flush any pending trace data. Once all child processes have acknowledged the stopRecording request, callback will be called with a file that contains the traced data. Trace data will be written into resultFilePath if it is not empty or into a temporary file. The actual file path will be passed to callback if it's not null.",
+        "parameters": {
+          "resultFilePath": {
+            "name": "resultFilePath",
+            "type": "String"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "startMonitoring": {
+        "name": "startMonitoring",
+        "signature": "(options, callback)",
+        "description": "Start monitoring on all processes. Monitoring begins immediately locally and asynchronously on child processes as soon as they receive the startMonitoring request. Once all child processes have acknowledged the startMonitoring request the callback will be called.",
+        "parameters": {
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "properties": {
+              "categoryFilter": {
+                "name": "categoryFilter",
+                "type": "String",
+                "description": ""
+              },
+              "traceOptions": {
+                "name": "traceOptions",
+                "type": "String",
+                "description": ""
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "stopMonitoring": {
+        "name": "stopMonitoring",
+        "signature": "(callback)",
+        "description": "Stop monitoring on all processes. Once all child processes have acknowledged the stopMonitoring request the callback is called.",
+        "parameters": {
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "captureMonitoringSnapshot": {
+        "name": "captureMonitoringSnapshot",
+        "signature": "(resultFilePath, callback)",
+        "description": "Get the current monitoring traced data. Child processes typically cache trace data and only rarely flush and send trace data back to the main process. This is because it may be an expensive operation to send the trace data over IPC and we would like to avoid unneeded runtime overhead from tracing. So, to end tracing, we must asynchronously ask all child processes to flush any pending trace data. Once all child processes have acknowledged the captureMonitoringSnapshot request the callback will be called with a file that contains the traced data.",
+        "parameters": {
+          "resultFilePath": {
+            "name": "resultFilePath",
+            "type": "String"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "getTraceBufferUsage": {
+        "name": "getTraceBufferUsage",
+        "signature": "(callback)",
+        "description": "Get the maximum usage across processes of trace buffer as a percentage of the full state. When the TraceBufferUsage value is determined the callback is called.",
+        "parameters": {
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "setWatchEvent": {
+        "name": "setWatchEvent",
+        "signature": "(categoryName, eventName, callback)",
+        "description": "callback will be called every time the given event occurs on any process.",
+        "parameters": {
+          "categoryName": {
+            "name": "categoryName",
+            "type": "String"
+          },
+          "eventName": {
+            "name": "eventName",
+            "type": "String"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "cancelWatchEvent": {
+        "name": "cancelWatchEvent",
+        "signature": "()",
+        "description": "Cancel the watch event. This may lead to a race condition with the watch event callback if tracing is enabled."
+      }
+    }
+  },
+  "dialog": {
+    "name": "dialog",
+    "description": "Display native system dialogs for opening and saving files, alerting, etc.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Module",
+    "slug": "dialog",
+    "websiteUrl": "http://electron.atom.io/docs/api/dialog",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/dialog.md",
+    "methods": {
+      "showOpenDialog": {
+        "name": "showOpenDialog",
+        "signature": "([browserWindow, ]options[, callback])",
+        "description": "On success this method returns an array of file paths chosen by the user, otherwise it returns undefined. The filters specifies an array of file types that can be displayed or selected when you want to limit the user to a specific type. For example: The extensions array should contain extensions without wildcards or dots (e.g. 'png' is good but '.png' and '*.png' are bad). To show all files, use the '*' wildcard (no other wildcard is supported). If a callback is passed, the API call will be asynchronous and the result will be passed via callback(filenames) Note: On Windows and Linux an open dialog can not be both a file selector and a directory selector, so if you set properties to ['openFile', 'openDirectory'] on these platforms, a directory selector will be shown.",
+        "parameters": {
+          "browserWindow": {
+            "name": "browserWindow",
+            "type": "BrowserWindow",
+            "description": "(optional)"
+          },
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "properties": {
+              "title": {
+                "name": "title",
+                "type": "String",
+                "description": ""
+              },
+              "defaultPath": {
+                "name": "defaultPath",
+                "type": "String",
+                "description": ""
+              },
+              "buttonLabel": {
+                "name": "buttonLabel",
+                "type": "String",
+                "description": "Custom label for the confirmation button, when left empty the default label will be used."
+              },
+              "filters": {
+                "name": "filters",
+                "type": "String[]",
+                "description": ""
+              },
+              "properties": {
+                "name": "properties",
+                "type": "String[]",
+                "description": "Contains which features the dialog should use, can contain , , , and ."
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function",
+            "description": "(optional)"
+          }
+        }
+      },
+      "showSaveDialog": {
+        "name": "showSaveDialog",
+        "signature": "([browserWindow, ]options[, callback])",
+        "description": "On success this method returns the path of the file chosen by the user, otherwise it returns undefined. The filters specifies an array of file types that can be displayed, see dialog.showOpenDialog for an example. If a callback is passed, the API call will be asynchronous and the result will be passed via callback(filename)",
+        "parameters": {
+          "browserWindow": {
+            "name": "browserWindow",
+            "type": "BrowserWindow",
+            "description": "(optional)"
+          },
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "properties": {
+              "title": {
+                "name": "title",
+                "type": "String",
+                "description": ""
+              },
+              "defaultPath": {
+                "name": "defaultPath",
+                "type": "String",
+                "description": ""
+              },
+              "buttonLabel": {
+                "name": "buttonLabel",
+                "type": "String",
+                "description": "Custom label for the confirmation button, when left empty the default label will be used."
+              },
+              "filters": {
+                "name": "filters",
+                "type": "String[]",
+                "description": ""
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function",
+            "description": "(optional)"
+          }
+        }
+      },
+      "showMessageBox": {
+        "name": "showMessageBox",
+        "signature": "([browserWindow, ]options[, callback])",
+        "description": "Shows a message box, it will block the process until the message box is closed. It returns the index of the clicked button. If a callback is passed, the API call will be asynchronous and the result will be passed via callback(response).",
+        "parameters": {
+          "browserWindow": {
+            "name": "browserWindow",
+            "type": "BrowserWindow",
+            "description": "(optional)"
+          },
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "properties": {
+              "type": {
+                "name": "type",
+                "type": "String",
+                "description": "Can be , , , or . On Windows, \"question\" displays the same icon as \"info\", unless you set an icon using the \"icon\" option."
+              },
+              "buttons": {
+                "name": "buttons",
+                "type": "String[]",
+                "description": "Array of texts for buttons. On Windows, an empty array will result in one button labeled \"OK\"."
+              },
+              "defaultId": {
+                "name": "defaultId",
+                "type": "Integer",
+                "description": "Index of the button in the buttons array which will be selected by default when the message box opens."
+              },
+              "title": {
+                "name": "title",
+                "type": "String",
+                "description": "Title of the message box, some platforms will not show it."
+              },
+              "message": {
+                "name": "message",
+                "type": "String",
+                "description": "Content of the message box."
+              },
+              "detail": {
+                "name": "detail",
+                "type": "String",
+                "description": "Extra information of the message."
+              },
+              "icon": {
+                "name": "icon",
+                "type": "NativeImage",
+                "description": ""
+              },
+              "cancelId": {
+                "name": "cancelId",
+                "type": "Integer",
+                "description": "The value will be returned when user cancels the dialog instead of clicking the buttons of the dialog. By default it is the index of the buttons that have \"cancel\" or \"no\" as label, or 0 if there is no such buttons. On macOS and Windows the index of \"Cancel\" button will always be used as , not matter whether it is already specified."
+              },
+              "noLink": {
+                "name": "noLink",
+                "type": "Boolean",
+                "description": "On Windows Electron will try to figure out which one of the are common buttons (like \"Cancel\" or \"Yes\"), and show the others as command links in the dialog. This can make the dialog appear in the style of modern Windows apps. If you don't like this behavior, you can set to ."
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "showErrorBox": {
+        "name": "showErrorBox",
+        "signature": "(title, content)",
+        "description": "Displays a modal dialog that shows an error message. This API can be called safely before the ready event the app module emits, it is usually used to report errors in early stage of startup.  If called before the app readyevent on Linux, the message will be emitted to stderr, and no GUI dialog will appear.",
+        "parameters": {
+          "title": {
+            "name": "title",
+            "type": "String",
+            "description": "The title to display in the error box"
+          },
+          "content": {
+            "name": "content",
+            "type": "String",
+            "description": "The text content to display in the error box"
+          }
+        }
+      }
+    }
+  },
+  "ipcMain": {
+    "name": "ipcMain",
+    "description": "Communicate asynchronously from the main process to renderer processes.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Module",
+    "slug": "ipc-main",
+    "websiteUrl": "http://electron.atom.io/docs/api/ipc-main",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/ipc-main.md"
+  },
+  "globalShortcut": {
+    "name": "globalShortcut",
+    "description": "Detect keyboard events when the application does not have keyboard focus.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Module",
+    "slug": "global-shortcut",
+    "websiteUrl": "http://electron.atom.io/docs/api/global-shortcut",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/global-shortcut.md",
+    "methods": {
+      "register": {
+        "name": "register",
+        "signature": "(accelerator, callback)",
+        "description": "Registers a global shortcut of accelerator. The callback is called when the registered shortcut is pressed by the user. When the accelerator is already taken by other applications, this call will silently fail. This behavior is intended by operating systems, since they don't want applications to fight for global shortcuts.",
+        "parameters": {
+          "accelerator": {
+            "name": "accelerator",
+            "type": "Accelerator"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "isRegistered": {
+        "name": "isRegistered",
+        "signature": "(accelerator)",
+        "description": "When the accelerator is already taken by other applications, this call will still return false. This behavior is intended by operating systems, since they don't want applications to fight for global shortcuts.",
+        "parameters": {
+          "accelerator": {
+            "name": "accelerator",
+            "type": "Accelerator"
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether this application has registered accelerator."
+        }
+      },
+      "unregister": {
+        "name": "unregister",
+        "signature": "(accelerator)",
+        "description": "Unregisters the global shortcut of accelerator.",
+        "parameters": {
+          "accelerator": {
+            "name": "accelerator",
+            "type": "Accelerator"
+          }
+        }
+      },
+      "unregisterAll": {
+        "name": "unregisterAll",
+        "signature": "()",
+        "description": "Unregisters all of the global shortcuts."
+      }
+    }
+  },
+  "Menu": {
+    "name": "Menu",
+    "description": "Create native application menus and context menus.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Class",
+    "slug": "menu",
+    "websiteUrl": "http://electron.atom.io/docs/api/menu",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/menu.md",
+    "staticMethods": {
+      "setApplicationMenu": {
+        "name": "setApplicationMenu",
+        "signature": "(menu)",
+        "description": "Sets menu as the application menu on macOS. On Windows and Linux, the menu will be set as each window's top menu. Note: This API has to be called after the ready event of app module.",
+        "parameters": {
+          "menu": {
+            "name": "menu",
+            "type": "Menu"
+          }
+        }
+      },
+      "getApplicationMenu": {
+        "name": "getApplicationMenu",
+        "signature": "()",
+        "description": "Returns the application menu (an instance of Menu), if set, or null, if not set."
+      },
+      "sendActionToFirstResponder": {
+        "name": "sendActionToFirstResponder",
+        "signature": "(action)",
+        "platforms": {},
+        "description": "Sends the action to the first responder of application. This is used for emulating default Cocoa menu behaviors, usually you would just use the role property of MenuItem. See the macOS Cocoa Event Handling Guide for more information on macOS' native actions.",
+        "parameters": {
+          "action": {
+            "name": "action",
+            "type": "String"
+          }
+        }
+      },
+      "buildFromTemplate": {
+        "name": "buildFromTemplate",
+        "signature": "(template)",
+        "description": "Generally, the template is just an array of options for constructing a MenuItem. The usage can be referenced above. You can also attach other fields to the element of the template and they will become properties of the constructed menu items.",
+        "parameters": {
+          "template": {
+            "name": "template",
+            "type": "MenuItem[]"
+          }
+        }
+      }
+    },
+    "constructorMethod": {
+      "signature": "()"
+    },
+    "instanceName": "menu",
+    "instanceMethods": {
+      "popup": {
+        "name": "popup",
+        "signature": "([browserWindow, x, y, positioningItem])",
+        "description": "Pops up this menu as a context menu in the browserWindow.",
+        "parameters": {
+          "browserWindow": {
+            "name": "browserWindow",
+            "type": "BrowserWindow",
+            "description": "(optional) - Default is `BrowserWindow.getFocusedWindow()`."
+          },
+          "x": {
+            "name": "x",
+            "type": "Number",
+            "description": "(optional) - Default is the current mouse cursor position."
+          },
+          "y": {
+            "name": "y",
+            "type": "Number",
+            "description": "( if `x` is used) - Default is the current mouse cursor position."
+          },
+          "positioningItem": {
+            "name": "positioningItem",
+            "type": "Number",
+            "description": "(optional) - The index of the menu item to be positioned under the mouse cursor at the specified coordinates. Default is -1."
+          }
+        }
+      },
+      "append": {
+        "name": "append",
+        "signature": "(menuItem)",
+        "description": "Appends the menuItem to the menu.",
+        "parameters": {
+          "menuItem": {
+            "name": "menuItem",
+            "type": "MenuItem"
+          }
+        }
+      },
+      "insert": {
+        "name": "insert",
+        "signature": "(pos, menuItem)",
+        "description": "Inserts the menuItem to the pos position of the menu.",
+        "parameters": {
+          "pos": {
+            "name": "pos",
+            "type": "Integer"
+          },
+          "menuItem": {
+            "name": "menuItem",
+            "type": "MenuItem"
+          }
+        }
+      }
+    },
+    "instanceProperties": {
+      "items": {
+        "name": "items",
+        "description": "A MenuItem[] array containing the menu's items."
+      }
+    }
+  },
+  "MenuItem": {
+    "name": "MenuItem",
+    "description": "Add items to native application menus and context menus.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Class",
+    "slug": "menu-item",
+    "websiteUrl": "http://electron.atom.io/docs/api/menu-item",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/menu-item.md",
+    "constructorMethod": {
+      "signature": "(options)",
+      "parameters": [
+        {
+          "name": "options",
+          "type": "Object",
+          "properties": [
+            {
+              "name": "click",
+              "type": "Function",
+              "description": "Will be called with when the menu item is clicked."
+            },
+            {
+              "name": "role",
+              "type": "String",
+              "description": "Define the action of the menu item, when specified the property will be ignored."
+            },
+            {
+              "name": "type",
+              "type": "String",
+              "description": "Can be , , , or ."
+            },
+            {
+              "name": "label",
+              "type": "String",
+              "description": ""
+            },
+            {
+              "name": "sublabel",
+              "type": "String",
+              "description": ""
+            },
+            {
+              "name": "accelerator",
+              "type": "Accelerator",
+              "description": ""
+            },
+            {
+              "name": "icon",
+              "type": "NativeImage",
+              "description": ""
+            },
+            {
+              "name": "enabled",
+              "type": "Boolean",
+              "description": "If false, the menu item will be greyed out and unclickable."
+            },
+            {
+              "name": "visible",
+              "type": "Boolean",
+              "description": "If false, the menu item will be entirely hidden."
+            },
+            {
+              "name": "checked",
+              "type": "Boolean",
+              "description": "Should only be specified for or type menu items."
+            },
+            {
+              "name": "submenu",
+              "type": "Menu",
+              "description": "Should be specified for type menu items. If is specified, the can be omitted. If the value is not a then it will be automatically converted to one using ."
+            },
+            {
+              "name": "id",
+              "type": "String",
+              "description": "Unique within a single menu. If defined then it can be used as a reference to this item by the position attribute."
+            },
+            {
+              "name": "position",
+              "type": "String",
+              "description": "This field allows fine-grained definition of the specific location within a given menu."
+            }
+          ]
+        }
+      ]
+    },
+    "instanceName": "menuItem",
+    "instanceProperties": {
+      "enabled": {
+        "name": "enabled",
+        "description": "A Boolean indicating whether the item is enabled, this property can be dynamically changed."
+      },
+      "visible": {
+        "name": "visible",
+        "description": "A Boolean indicating whether the item is visible, this property can be dynamically changed."
+      },
+      "checked": {
+        "name": "checked",
+        "description": "A Boolean indicating whether the item is checked, this property can be dynamically changed. A checkbox menu item will toggle the checked property on and off when selected. A radio menu item will turn on its checked property when clicked, and will turn off that property for all adjacent items in the same menu. You can add a click function for additional behavior."
+      }
+    }
+  },
+  "powerMonitor": {
+    "name": "powerMonitor",
+    "description": "Monitor power state changes.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Module",
+    "slug": "power-monitor",
+    "websiteUrl": "http://electron.atom.io/docs/api/power-monitor",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/power-monitor.md",
+    "events": {
+      "suspend": {
+        "name": "suspend",
+        "description": "Emitted when the system is suspending."
+      },
+      "resume": {
+        "name": "resume",
+        "description": "Emitted when system is resuming."
+      },
+      "on-ac": {
+        "name": "on-ac",
+        "description": "Emitted when the system changes to AC power.",
+        "platforms": {}
+      },
+      "on-battery": {
+        "name": "on-battery",
+        "description": "Emitted when system changes to battery power.",
+        "platforms": {}
+      }
+    }
+  },
+  "powerSaveBlocker": {
+    "name": "powerSaveBlocker",
+    "description": "Block the system from entering low-power (sleep) mode.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Module",
+    "slug": "power-save-blocker",
+    "websiteUrl": "http://electron.atom.io/docs/api/power-save-blocker",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/power-save-blocker.md",
+    "methods": {
+      "start": {
+        "name": "start",
+        "signature": "(type)",
+        "description": "Starts preventing the system from entering lower-power mode. Returns an integer identifying the power save blocker. Note: prevent-display-sleep has higher precedence over prevent-app-suspension. Only the highest precedence type takes effect. In other words, prevent-display-sleep always takes precedence over prevent-app-suspension. For example, an API calling A requests for prevent-app-suspension, and another calling B requests for prevent-display-sleep. prevent-display-sleep will be used until B stops its request. After that, prevent-app-suspension is used.",
+        "parameters": {
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "Power save blocker type.",
+            "possibleValues": {}
+          }
+        },
+        "returns": {
+          "type": "Integer",
+          "description": "The blocker ID that is assigned to this power blocker"
+        }
+      },
+      "stop": {
+        "name": "stop",
+        "signature": "(id)",
+        "description": "Stops the specified power save blocker.",
+        "parameters": {
+          "id": {
+            "name": "id",
+            "type": "Integer",
+            "description": "The power save blocker id returned by `powerSaveBlocker.start`."
+          }
+        }
+      },
+      "isStarted": {
+        "name": "isStarted",
+        "signature": "(id)",
+        "parameters": {
+          "id": {
+            "name": "id",
+            "type": "Integer",
+            "description": "The power save blocker id returned by `powerSaveBlocker.start`."
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the corresponding powerSaveBlocker has started."
+        }
+      }
+    }
+  },
+  "protocol": {
+    "name": "protocol",
+    "description": "Register a custom protocol and intercept existing protocol requests.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Module",
+    "slug": "protocol",
+    "websiteUrl": "http://electron.atom.io/docs/api/protocol",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/protocol.md",
+    "methods": {
+      "registerStandardSchemes": {
+        "name": "registerStandardSchemes",
+        "signature": "(schemes)",
+        "description": "A standard scheme adheres to what RFC 3986 calls generic URI syntax. For example http and https are standard schemes, while file is not. Registering a scheme as standard, will allow relative and absolute resources to be resolved correctly when served. Otherwise the scheme will behave like the file protocol, but without the ability to resolve relative URLs. For example when you load following page with custom protocol without registering it as standard scheme, the image will not be loaded because non-standard schemes can not recognize relative URLs: Registering a scheme as standard will allow access to files through the FileSystem API. Otherwise the renderer will throw a security error for the scheme. By default web storage apis (localStorage, sessionStorage, webSQL, indexedDB, cookies) are disabled for non standard schemes. So in general if you want to register a custom protocol to replace the http protocol, you have to register it as a standard scheme: Note: This method can only be used before the ready event of the app module gets emitted.",
+        "parameters": {
+          "schemes": {
+            "name": "schemes",
+            "type": "String[]",
+            "description": "Custom schemes to be registered as standard schemes."
+          }
+        }
+      },
+      "registerServiceWorkerSchemes": {
+        "name": "registerServiceWorkerSchemes",
+        "signature": "(schemes)",
+        "parameters": {
+          "schemes": {
+            "name": "schemes",
+            "type": "String[]",
+            "description": "Custom schemes to be registered to handle service workers."
+          }
+        }
+      },
+      "registerFileProtocol": {
+        "name": "registerFileProtocol",
+        "signature": "(scheme, handler[, completion])",
+        "description": "Registers a protocol of scheme that will send the file as a response. The handler will be called with handler(request, callback) when a request is going to be created with scheme. completion will be called with completion(null) when scheme is successfully registered or completion(error) when failed. The uploadData is an array of data objects: To handle the request, the callback should be called with either the file's path or an object that has a path property, e.g. callback(filePath) or callback({path: filePath}). When callback is called with nothing, a number, or an object that has an error property, the request will fail with the error number you specified. For the available error numbers you can use, please see the net error list. By default the scheme is treated like http:, which is parsed differently than protocols that follow the \"generic URI syntax\" like file:, so you probably want to call protocol.registerStandardSchemes to have your scheme treated as a standard scheme.",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          },
+          "handler": {
+            "name": "handler",
+            "type": "Function"
+          },
+          "completion": {
+            "name": "completion",
+            "type": "Function",
+            "description": "(optional)"
+          }
+        }
+      },
+      "registerBufferProtocol": {
+        "name": "registerBufferProtocol",
+        "signature": "(scheme, handler[, completion])",
+        "description": "Registers a protocol of scheme that will send a Buffer as a response. The usage is the same with registerFileProtocol, except that the callback should be called with either a Buffer object or an object that has the data, mimeType, and charset properties. Example:",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          },
+          "handler": {
+            "name": "handler",
+            "type": "Function"
+          },
+          "completion": {
+            "name": "completion",
+            "type": "Function",
+            "description": "(optional)"
+          }
+        }
+      },
+      "registerStringProtocol": {
+        "name": "registerStringProtocol",
+        "signature": "(scheme, handler[, completion])",
+        "description": "Registers a protocol of scheme that will send a String as a response. The usage is the same with registerFileProtocol, except that the callback should be called with either a String or an object that has the data, mimeType, and charset properties.",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          },
+          "handler": {
+            "name": "handler",
+            "type": "Function"
+          },
+          "completion": {
+            "name": "completion",
+            "type": "Function",
+            "description": "(optional)"
+          }
+        }
+      },
+      "registerHttpProtocol": {
+        "name": "registerHttpProtocol",
+        "signature": "(scheme, handler[, completion])",
+        "description": "Registers a protocol of scheme that will send an HTTP request as a response. The usage is the same with registerFileProtocol, except that the callback should be called with a redirectRequest object that has the url, method, referrer, uploadData and session properties. By default the HTTP request will reuse the current session. If you want the request to have a different session you should set session to null. For POST requests the uploadData object must be provided.",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          },
+          "handler": {
+            "name": "handler",
+            "type": "Function"
+          },
+          "completion": {
+            "name": "completion",
+            "type": "Function",
+            "description": "(optional)"
+          }
+        }
+      },
+      "unregisterProtocol": {
+        "name": "unregisterProtocol",
+        "signature": "(scheme[, completion])",
+        "description": "Unregisters the custom protocol of scheme.",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          },
+          "completion": {
+            "name": "completion",
+            "type": "Function",
+            "description": "(optional)"
+          }
+        }
+      },
+      "isProtocolHandled": {
+        "name": "isProtocolHandled",
+        "signature": "(scheme, callback)",
+        "description": "The callback will be called with a boolean that indicates whether there is already a handler for scheme.",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "interceptFileProtocol": {
+        "name": "interceptFileProtocol",
+        "signature": "(scheme, handler[, completion])",
+        "description": "Intercepts scheme protocol and uses handler as the protocol's new handler which sends a file as a response.",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          },
+          "handler": {
+            "name": "handler",
+            "type": "Function"
+          },
+          "completion": {
+            "name": "completion",
+            "type": "Function",
+            "description": "(optional)"
+          }
+        }
+      },
+      "interceptStringProtocol": {
+        "name": "interceptStringProtocol",
+        "signature": "(scheme, handler[, completion])",
+        "description": "Intercepts scheme protocol and uses handler as the protocol's new handler which sends a String as a response.",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          },
+          "handler": {
+            "name": "handler",
+            "type": "Function"
+          },
+          "completion": {
+            "name": "completion",
+            "type": "Function",
+            "description": "(optional)"
+          }
+        }
+      },
+      "interceptBufferProtocol": {
+        "name": "interceptBufferProtocol",
+        "signature": "(scheme, handler[, completion])",
+        "description": "Intercepts scheme protocol and uses handler as the protocol's new handler which sends a Buffer as a response.",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          },
+          "handler": {
+            "name": "handler",
+            "type": "Function"
+          },
+          "completion": {
+            "name": "completion",
+            "type": "Function",
+            "description": "(optional)"
+          }
+        }
+      },
+      "interceptHttpProtocol": {
+        "name": "interceptHttpProtocol",
+        "signature": "(scheme, handler[, completion])",
+        "description": "Intercepts scheme protocol and uses handler as the protocol's new handler which sends a new HTTP request as a response.",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          },
+          "handler": {
+            "name": "handler",
+            "type": "Function"
+          },
+          "completion": {
+            "name": "completion",
+            "type": "Function",
+            "description": "(optional)"
+          }
+        }
+      },
+      "uninterceptProtocol": {
+        "name": "uninterceptProtocol",
+        "signature": "(scheme[, completion])",
+        "description": "Remove the interceptor installed for scheme and restore its original handler.",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          },
+          "completion": {
+            "name": "completion",
+            "type": "Function"
+          }
+        }
+      }
+    }
+  },
+  "screen": {
+    "name": "screen",
+    "description": "Retrieve information about screen size, displays, cursor position, etc.",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Module",
+    "slug": "screen",
+    "websiteUrl": "http://electron.atom.io/docs/api/screen",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/screen.md",
+    "methods": {
+      "getCursorScreenPoint": {
+        "name": "getCursorScreenPoint",
+        "signature": "()",
+        "description": "The current absolute position of the mouse pointer.",
+        "returns": {
+          "type": "Object",
+          "properties": [
+            {
+              "name": "x",
+              "type": "Integer",
+              "description": ""
+            },
+            {
+              "name": "y",
+              "type": "Integer",
+              "description": ""
+            }
+          ]
+        }
+      },
+      "getPrimaryDisplay": {
+        "name": "getPrimaryDisplay",
+        "signature": "()",
+        "returns": {
+          "type": "Display",
+          "description": "The primary display."
+        }
+      },
+      "getAllDisplays": {
+        "name": "getAllDisplays",
+        "signature": "()",
+        "returns": {
+          "type": "Display[]",
+          "description": "An array of displays that are currently available."
+        }
+      },
+      "getDisplayNearestPoint": {
+        "name": "getDisplayNearestPoint",
+        "signature": "(point)",
+        "parameters": {
+          "point": {
+            "name": "point",
+            "type": "Object",
+            "properties": {
+              "x": {
+                "name": "x",
+                "type": "Integer",
+                "description": ""
+              },
+              "y": {
+                "name": "y",
+                "type": "Integer",
+                "description": ""
+              }
+            }
+          }
+        },
+        "returns": {
+          "type": "Display",
+          "description": "The display nearest the specified point."
+        }
+      },
+      "getDisplayMatching": {
+        "name": "getDisplayMatching",
+        "signature": "(rect)",
+        "parameters": {
+          "rect": {
+            "name": "rect",
+            "type": "Rectangle"
+          }
+        },
+        "returns": {
+          "type": "Display",
+          "description": "The display that most closely intersects the provided bounds."
+        }
+      }
+    },
+    "events": {
+      "display-added": {
+        "name": "display-added",
+        "description": "Emitted when newDisplay has been added.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "newDisplay": {
+            "name": "newDisplay",
+            "type": "Display"
+          }
+        }
+      },
+      "display-removed": {
+        "name": "display-removed",
+        "description": "Emitted when oldDisplay has been removed.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "oldDisplay": {
+            "name": "oldDisplay",
+            "type": "Display"
+          }
+        }
+      },
+      "display-metrics-changed": {
+        "name": "display-metrics-changed",
+        "description": "Emitted when one or more metrics change in a display. The changedMetrics is an array of strings that describe the changes. Possible changes are bounds, workArea, scaleFactor and rotation.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "display": {
+            "name": "display",
+            "type": "Display"
+          },
+          "changedMetrics": {
+            "name": "changedMetrics",
+            "type": "String[]"
+          }
+        }
+      }
+    }
+  },
+  "session": {
+    "name": "session",
+    "description": "Manage browser sessions, cookies, cache, proxy settings, etc.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Module",
+    "slug": "session",
+    "websiteUrl": "http://electron.atom.io/docs/api/session",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/session.md",
+    "methods": {
+      "fromPartition": {
+        "name": "fromPartition",
+        "signature": "(partition[, options])",
+        "description": "If partition starts with persist:, the page will use a persistent session available to all pages in the app with the same partition. if there is no persist: prefix, the page will use an in-memory session. If the partition is empty then default session of the app will be returned. To create a Session with options, you have to ensure the Session with the partition has never been used before. There is no way to change the options of an existing Session object.",
+        "parameters": {
+          "partition": {
+            "name": "partition",
+            "type": "String"
+          },
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "properties": {
+              "cache": {
+                "name": "cache",
+                "type": "Boolean",
+                "description": "Whether to enable cache."
+              }
+            }
+          }
+        },
+        "returns": {
+          "type": "Session",
+          "description": "A session instance from partition string. When there is an existing Session with the same partition, it will be returned; othewise a new Session instance will be created with options."
+        }
+      }
+    }
+  },
+  "Session": {
+    "name": "Session",
+    "description": "Get and set properties of a session.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Class",
+    "slug": "session",
+    "websiteUrl": "http://electron.atom.io/docs/api/session",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/session.md",
+    "instanceName": "ses",
+    "instanceMethods": {
+      "getCacheSize": {
+        "name": "getCacheSize",
+        "signature": "(callback)",
+        "description": "Returns the session's current cache size.",
+        "parameters": {
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "clearCache": {
+        "name": "clearCache",
+        "signature": "(callback)",
+        "description": "Clears the session’s HTTP cache.",
+        "parameters": {
+          "callback": {
+            "name": "callback",
+            "type": "Function",
+            "description": "Called when operation is done"
+          }
+        }
+      },
+      "clearStorageData": {
+        "name": "clearStorageData",
+        "signature": "([options, callback])",
+        "description": "Clears the data of web storages.",
+        "parameters": {
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "description": "(optional)",
+            "properties": {
+              "origin": {
+                "name": "origin",
+                "type": "String",
+                "description": "Should follow ’s representation ."
+              },
+              "storages": {
+                "name": "storages",
+                "type": "String[]",
+                "description": "The types of storages to clear, can contain: , , , , , , ,"
+              },
+              "quotas": {
+                "name": "quotas",
+                "type": "String[]",
+                "description": "The types of quotas to clear, can contain: , , ."
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function",
+            "description": "(optional) - Called when operation is done."
+          }
+        }
+      },
+      "flushStorageData": {
+        "name": "flushStorageData",
+        "signature": "()",
+        "description": "Writes any unwritten DOMStorage data to disk."
+      },
+      "setProxy": {
+        "name": "setProxy",
+        "signature": "(config, callback)",
+        "description": "Sets the proxy settings. When pacScript and proxyRules are provided together, the proxyRules option is ignored and pacScript configuration is applied. The proxyRules has to follow the rules below: For example: The proxyBypassRules is a comma separated list of rules described below:",
+        "parameters": {
+          "config": {
+            "name": "config",
+            "type": "Object",
+            "properties": {
+              "pacScript": {
+                "name": "pacScript",
+                "type": "String",
+                "description": "The URL associated with the PAC file."
+              },
+              "proxyRules": {
+                "name": "proxyRules",
+                "type": "String",
+                "description": "Rules indicating which proxies to use."
+              },
+              "proxyBypassRules": {
+                "name": "proxyBypassRules",
+                "type": "String",
+                "description": "Rules indicating which URLs should bypass the proxy settings."
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function",
+            "description": "Called when operation is done."
+          }
+        }
+      }
+    },
+    "instanceProperties": {
+      "cookies": {
+        "name": "cookies",
+        "description": "A Cookies object for this session."
+      },
+      "webRequest": {
+        "name": "webRequest",
+        "description": "A WebRequest object for this session."
+      },
+      "protocol": {
+        "name": "protocol",
+        "description": "A Protocol object (an instance of protocol module) for this session."
+      }
+    },
+    "instanceEvents": {
+      "will-download": {
+        "name": "will-download",
+        "description": "Emitted when Electron is about to download item in webContents. Calling event.preventDefault() will cancel the download and item will not be available from next tick of the process.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "item": {
+            "name": "item",
+            "type": "DownloadItem"
+          },
+          "webContents": {
+            "name": "webContents",
+            "type": "WebContents"
+          }
+        }
+      }
+    }
+  },
+  "Cookies": {
+    "name": "Cookies",
+    "description": "Query and modify a session's cookies.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Class",
+    "slug": "cookies",
+    "websiteUrl": "http://electron.atom.io/docs/api/cookies",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/cookies.md",
+    "instanceName": "cookies",
+    "instanceMethods": {
+      "get": {
+        "name": "get",
+        "signature": "(filter, callback)",
+        "description": "Sends a request to get all cookies matching details, callback will be called with callback(error, cookies) on complete. cookies is an Array of cookie objects.",
+        "parameters": {
+          "filter": {
+            "name": "filter",
+            "type": "Object",
+            "properties": {
+              "url": {
+                "name": "url",
+                "type": "String",
+                "description": "(optional) - Retrieves cookies which are associated with . Empty implies retrieving cookies of all urls."
+              },
+              "name": {
+                "name": "name",
+                "type": "String",
+                "description": "(optional) - Filters cookies by name."
+              },
+              "domain": {
+                "name": "domain",
+                "type": "String",
+                "description": "(optional) - Retrieves cookies whose domains match or are subdomains of"
+              },
+              "path": {
+                "name": "path",
+                "type": "String",
+                "description": "(optional) - Retrieves cookies whose path matches ."
+              },
+              "secure": {
+                "name": "secure",
+                "type": "Boolean",
+                "description": "(optional) - Filters cookies by their Secure property."
+              },
+              "session": {
+                "name": "session",
+                "type": "Boolean",
+                "description": "(optional) - Filters out session or persistent cookies."
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "set": {
+        "name": "set",
+        "signature": "(details, callback)",
+        "description": "Sets a cookie with details, callback will be called with callback(error) on complete.",
+        "parameters": {
+          "details": {
+            "name": "details",
+            "type": "Object",
+            "properties": {
+              "url": {
+                "name": "url",
+                "type": "String",
+                "description": "The url to associate the cookie with."
+              },
+              "name": {
+                "name": "name",
+                "type": "String",
+                "description": "The name of the cookie. Empty by default if omitted."
+              },
+              "value": {
+                "name": "value",
+                "type": "String",
+                "description": "The value of the cookie. Empty by default if omitted."
+              },
+              "domain": {
+                "name": "domain",
+                "type": "String",
+                "description": "The domain of the cookie. Empty by default if omitted."
+              },
+              "path": {
+                "name": "path",
+                "type": "String",
+                "description": "The path of the cookie. Empty by default if omitted."
+              },
+              "secure": {
+                "name": "secure",
+                "type": "Boolean",
+                "description": "Whether the cookie should be marked as Secure. Defaults to false."
+              },
+              "httpOnly": {
+                "name": "httpOnly",
+                "type": "Boolean",
+                "description": "Whether the cookie should be marked as HTTP only. Defaults to false."
+              },
+              "expirationDate": {
+                "name": "expirationDate",
+                "type": "Double",
+                "description": "- The expiration date of the cookie as the number of seconds since the UNIX epoch. If omitted then the cookie becomes a session cookie and will not be retained between sessions."
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "remove": {
+        "name": "remove",
+        "signature": "(url, name, callback)",
+        "description": "Removes the cookies matching url and name, callback will called with callback() on complete.",
+        "parameters": {
+          "url": {
+            "name": "url",
+            "type": "String",
+            "description": "The URL associated with the cookie."
+          },
+          "name": {
+            "name": "name",
+            "type": "String",
+            "description": "The name of cookie to remove."
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      }
+    },
+    "instanceEvents": {
+      "changed": {
+        "name": "changed",
+        "description": "Emitted when a cookie is changed because it was added, edited, removed, or expired.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "cookie": {
+            "name": "cookie",
+            "type": "Object",
+            "description": "The cookie that was changed"
+          },
+          "cause": {
+            "name": "cause",
+            "type": "String",
+            "description": "The cause of the change with one of the following values:",
+            "possibleValues": {}
+          },
+          "removed": {
+            "name": "removed",
+            "type": "Boolean",
+            "description": "`true` if the cookie was removed, `false` otherwise."
+          }
+        }
+      }
+    }
+  },
+  "WebRequest": {
+    "name": "WebRequest",
+    "description": "Intercept and modify the contents of a request at various stages of its lifetime.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Class",
+    "slug": "web-request",
+    "websiteUrl": "http://electron.atom.io/docs/api/web-request",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/web-request.md",
+    "instanceName": "webRequest",
+    "instanceMethods": {
+      "onBeforeRequest": {
+        "name": "onBeforeRequest",
+        "signature": "([filter, ]listener)",
+        "description": "The listener will be called with listener(details, callback) when a request is about to occur. The uploadData is an array of data objects: The callback has to be called with an response object:",
+        "parameters": {
+          "filter": {
+            "name": "filter",
+            "type": "Object"
+          },
+          "listener": {
+            "name": "listener",
+            "type": "Function"
+          }
+        }
+      },
+      "onBeforeSendHeaders": {
+        "name": "onBeforeSendHeaders",
+        "signature": "([filter, ]listener)",
+        "description": "The listener will be called with listener(details, callback) before sending an HTTP request, once the request headers are available. This may occur after a TCP connection is made to the server, but before any http data is sent. The callback has to be called with an response object:",
+        "parameters": {
+          "filter": {
+            "name": "filter",
+            "type": "Object"
+          },
+          "listener": {
+            "name": "listener",
+            "type": "Function"
+          }
+        }
+      },
+      "onSendHeaders": {
+        "name": "onSendHeaders",
+        "signature": "([filter, ]listener)",
+        "description": "The listener will be called with listener(details) just before a request is going to be sent to the server, modifications of previous onBeforeSendHeaders response are visible by the time this listener is fired.",
+        "parameters": {
+          "filter": {
+            "name": "filter",
+            "type": "Object"
+          },
+          "listener": {
+            "name": "listener",
+            "type": "Function"
+          }
+        }
+      },
+      "onHeadersReceived": {
+        "name": "onHeadersReceived",
+        "signature": "([filter, ]listener)",
+        "description": "The listener will be called with listener(details, callback) when HTTP response headers of a request have been received. The callback has to be called with an response object:",
+        "parameters": {
+          "filter": {
+            "name": "filter",
+            "type": "Object"
+          },
+          "listener": {
+            "name": "listener",
+            "type": "Function"
+          }
+        }
+      },
+      "onResponseStarted": {
+        "name": "onResponseStarted",
+        "signature": "([filter, ]listener)",
+        "description": "The listener will be called with listener(details) when first byte of the response body is received. For HTTP requests, this means that the status line and response headers are available.",
+        "parameters": {
+          "filter": {
+            "name": "filter",
+            "type": "Object"
+          },
+          "listener": {
+            "name": "listener",
+            "type": "Function"
+          }
+        }
+      },
+      "onBeforeRedirect": {
+        "name": "onBeforeRedirect",
+        "signature": "([filter, ]listener)",
+        "description": "The listener will be called with listener(details) when a server initiated redirect is about to occur.",
+        "parameters": {
+          "filter": {
+            "name": "filter",
+            "type": "Object"
+          },
+          "listener": {
+            "name": "listener",
+            "type": "Function"
+          }
+        }
+      },
+      "onCompleted": {
+        "name": "onCompleted",
+        "signature": "([filter, ]listener)",
+        "description": "The listener will be called with listener(details) when a request is completed.",
+        "parameters": {
+          "filter": {
+            "name": "filter",
+            "type": "Object"
+          },
+          "listener": {
+            "name": "listener",
+            "type": "Function"
+          }
+        }
+      },
+      "onErrorOccurred": {
+        "name": "onErrorOccurred",
+        "signature": "([filter, ]listener)",
+        "description": "The listener will be called with listener(details) when an error occurs.",
+        "parameters": {
+          "filter": {
+            "name": "filter",
+            "type": "Object"
+          },
+          "listener": {
+            "name": "listener",
+            "type": "Function"
+          }
+        }
+      }
+    }
+  },
+  "systemPreferences": {
+    "name": "systemPreferences",
+    "description": "Get system preferences.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Module",
+    "slug": "system-preferences",
+    "websiteUrl": "http://electron.atom.io/docs/api/system-preferences",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/system-preferences.md",
+    "methods": {
+      "isDarkMode": {
+        "name": "isDarkMode",
+        "signature": "()",
+        "platforms": {},
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the system is in Dark Mode."
+        }
+      },
+      "isSwipeTrackingFromScrollEventsEnabled": {
+        "name": "isSwipeTrackingFromScrollEventsEnabled",
+        "signature": "()",
+        "platforms": {},
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the Swipe between pages setting is on."
+        }
+      },
+      "postNotification": {
+        "name": "postNotification",
+        "signature": "(event, userInfo)",
+        "platforms": {},
+        "description": "Posts event as native notifications of macOS. The userInfo is an Object that contains the user information dictionary sent along with the notification.",
+        "parameters": {
+          "event": {
+            "name": "event",
+            "type": "String"
+          },
+          "userInfo": {
+            "name": "userInfo",
+            "type": "Object"
+          }
+        }
+      },
+      "postLocalNotification": {
+        "name": "postLocalNotification",
+        "signature": "(event, userInfo)",
+        "platforms": {},
+        "description": "Posts event as native notifications of macOS. The userInfo is an Object that contains the user information dictionary sent along with the notification.",
+        "parameters": {
+          "event": {
+            "name": "event",
+            "type": "String"
+          },
+          "userInfo": {
+            "name": "userInfo",
+            "type": "Object"
+          }
+        }
+      },
+      "subscribeNotification": {
+        "name": "subscribeNotification",
+        "signature": "(event, callback)",
+        "platforms": {},
+        "description": "Subscribes to native notifications of macOS, callback will be called with callback(event, userInfo) when the corresponding event happens. The userInfo is an Object that contains the user information dictionary sent along with the notification. The id of the subscriber is returned, which can be used to unsubscribe the event. Under the hood this API subscribes to NSDistributedNotificationCenter, example values of event are:",
+        "parameters": {
+          "event": {
+            "name": "event",
+            "type": "String"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "unsubscribeNotification": {
+        "name": "unsubscribeNotification",
+        "signature": "(id)",
+        "platforms": {},
+        "description": "Removes the subscriber with id.",
+        "parameters": {
+          "id": {
+            "name": "id",
+            "type": "Integer"
+          }
+        }
+      },
+      "subscribeLocalNotification": {
+        "name": "subscribeLocalNotification",
+        "signature": "(event, callback)",
+        "platforms": {},
+        "description": "Same as subscribeNotification, but uses NSNotificationCenter for local defaults. This is necessary for events such as NSUserDefaultsDidChangeNotification",
+        "parameters": {
+          "event": {
+            "name": "event",
+            "type": "String"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "unsubscribeLocalNotification": {
+        "name": "unsubscribeLocalNotification",
+        "signature": "(id)",
+        "platforms": {},
+        "description": "Same as unsubscribeNotification, but removes the subscriber from NSNotificationCenter.",
+        "parameters": {
+          "id": {
+            "name": "id",
+            "type": "Integer"
+          }
+        }
+      },
+      "getUserDefault": {
+        "name": "getUserDefault",
+        "signature": "(key, type)",
+        "platforms": {},
+        "description": "Get the value of key in system preferences. This API reads from NSUserDefaults on macOS, some popular key and types are:",
+        "parameters": {
+          "key": {
+            "name": "key",
+            "type": "String"
+          },
+          "type": {
+            "name": "type",
+            "type": "String",
+            "description": "Can be `string`, `boolean`, `integer`, `float`, `double`, `url`, `array`, `dictionary`"
+          }
+        }
+      },
+      "isAeroGlassEnabled": {
+        "name": "isAeroGlassEnabled",
+        "signature": "()",
+        "platforms": {},
+        "description": "This method returns true if DWM composition (Aero Glass) is enabled, and false otherwise. An example of using it to determine if you should create a transparent window or not (transparent windows won't work correctly when DWM composition is disabled):"
+      },
+      "getAccentColor": {
+        "name": "getAccentColor",
+        "signature": "()",
+        "platforms": {},
+        "returns": {
+          "type": "String",
+          "description": "The users current system wide accent color preference in RGBA hexadecimal form."
+        }
+      },
+      "getColor": {
+        "name": "getColor",
+        "signature": "(color)",
+        "platforms": {},
+        "parameters": {
+          "color": {
+            "name": "color",
+            "type": "String",
+            "description": "One of the following values:",
+            "possibleValues": {}
+          }
+        },
+        "returns": {
+          "type": "String",
+          "description": "The system color setting in RGB hexadecimal form (#ABCDEF). See the Windows docs for more details."
+        }
+      },
+      "isInvertedColorScheme": {
+        "name": "isInvertedColorScheme",
+        "signature": "()",
+        "platforms": {},
+        "returns": {
+          "type": "Boolean",
+          "description": "true if an inverted color scheme, such as a high contrast theme, is active, false otherwise."
+        }
+      }
+    },
+    "events": {
+      "accent-color-changed": {
+        "name": "accent-color-changed",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "newColor": {
+            "name": "newColor",
+            "type": "String",
+            "description": "The new RGBA color the user assigned to be there system accent color."
+          }
+        }
+      },
+      "color-changed": {
+        "name": "color-changed",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          }
+        }
+      },
+      "inverted-color-scheme-changed": {
+        "name": "inverted-color-scheme-changed",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "invertedColorScheme": {
+            "name": "invertedColorScheme",
+            "type": "Boolean",
+            "description": "`true` if an inverted color scheme, such as a high contrast theme, is being used, `false` otherwise."
+          }
+        }
+      }
+    }
+  },
+  "Tray": {
+    "name": "Tray",
+    "description": "Add icons and context menus to the system's notification area.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Class",
+    "slug": "tray",
+    "websiteUrl": "http://electron.atom.io/docs/api/tray",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/tray.md",
+    "constructorMethod": {
+      "signature": "(image)",
+      "parameters": [
+        {
+          "name": "image",
+          "type": "NativeImage"
+        }
+      ]
+    },
+    "instanceName": "tray",
+    "instanceMethods": {
+      "destroy": {
+        "name": "destroy",
+        "signature": "()",
+        "description": "Destroys the tray icon immediately."
+      },
+      "setImage": {
+        "name": "setImage",
+        "signature": "(image)",
+        "description": "Sets the image associated with this tray icon.",
+        "parameters": {
+          "image": {
+            "name": "image",
+            "type": "NativeImage"
+          }
+        }
+      },
+      "setPressedImage": {
+        "name": "setPressedImage",
+        "signature": "(image)",
+        "platforms": {},
+        "description": "Sets the image associated with this tray icon when pressed on macOS.",
+        "parameters": {
+          "image": {
+            "name": "image",
+            "type": "NativeImage"
+          }
+        }
+      },
+      "setToolTip": {
+        "name": "setToolTip",
+        "signature": "(toolTip)",
+        "description": "Sets the hover text for this tray icon.",
+        "parameters": {
+          "toolTip": {
+            "name": "toolTip",
+            "type": "String"
+          }
+        }
+      },
+      "setTitle": {
+        "name": "setTitle",
+        "signature": "(title)",
+        "platforms": {},
+        "description": "Sets the title displayed aside of the tray icon in the status bar.",
+        "parameters": {
+          "title": {
+            "name": "title",
+            "type": "String"
+          }
+        }
+      },
+      "setHighlightMode": {
+        "name": "setHighlightMode",
+        "signature": "(mode)",
+        "platforms": {},
+        "description": "Sets when the tray's icon background becomes highlighted (in blue). Note: You can use highlightMode with a BrowserWindow by toggling between 'never' and 'always' modes when the window visibility changes.",
+        "parameters": {
+          "mode": {
+            "name": "mode",
+            "type": "String",
+            "description": "Highlight mode with one of the following values:",
+            "possibleValues": {}
+          }
+        }
+      },
+      "displayBalloon": {
+        "name": "displayBalloon",
+        "signature": "(options)",
+        "platforms": {},
+        "description": "Displays a tray balloon.",
+        "parameters": {
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "properties": {
+              "icon": {
+                "name": "icon",
+                "type": "NativeImage",
+                "description": ""
+              },
+              "title": {
+                "name": "title",
+                "type": "String",
+                "description": ""
+              },
+              "content": {
+                "name": "content",
+                "type": "String",
+                "description": ""
+              }
+            }
+          }
+        }
+      },
+      "popUpContextMenu": {
+        "name": "popUpContextMenu",
+        "signature": "([menu, position])",
+        "platforms": {},
+        "description": "Pops up the context menu of the tray icon. When menu is passed, the menu will be shown instead of the tray icon's context menu. The position is only available on Windows, and it is (0, 0) by default.",
+        "parameters": {
+          "menu": {
+            "name": "menu",
+            "type": "Menu",
+            "description": "(optional)"
+          },
+          "position": {
+            "name": "position",
+            "type": "Object",
+            "description": "(optional) - The pop up position.",
+            "properties": {
+              "x": {
+                "name": "x",
+                "type": "Integer",
+                "description": ""
+              },
+              "y": {
+                "name": "y",
+                "type": "Integer",
+                "description": ""
+              }
+            }
+          }
+        }
+      },
+      "setContextMenu": {
+        "name": "setContextMenu",
+        "signature": "(menu)",
+        "description": "Sets the context menu for this icon.",
+        "parameters": {
+          "menu": {
+            "name": "menu",
+            "type": "Menu"
+          }
+        }
+      },
+      "getBounds": {
+        "name": "getBounds",
+        "signature": "()",
+        "platforms": {},
+        "description": "The bounds of this tray icon as Object.",
+        "returns": {
+          "type": "Rectangle"
+        }
+      },
+      "isDestroyed": {
+        "name": "isDestroyed",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the tray icon is destroyed."
+        }
+      }
+    },
+    "instanceEvents": {
+      "click": {
+        "name": "click",
+        "description": "Emitted when the tray icon is clicked.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "bounds": {
+            "name": "bounds",
+            "type": "Rectangle",
+            "description": "The bounds of tray icon"
+          }
+        }
+      },
+      "right-click": {
+        "name": "right-click",
+        "description": "Emitted when the tray icon is right clicked.",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "bounds": {
+            "name": "bounds",
+            "type": "Rectangle",
+            "description": "The bounds of tray icon"
+          }
+        }
+      },
+      "double-click": {
+        "name": "double-click",
+        "description": "Emitted when the tray icon is double clicked.",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "bounds": {
+            "name": "bounds",
+            "type": "Rectangle",
+            "description": "The bounds of tray icon"
+          }
+        }
+      },
+      "balloon-show": {
+        "name": "balloon-show",
+        "description": "Emitted when the tray balloon shows.",
+        "platforms": {}
+      },
+      "balloon-click": {
+        "name": "balloon-click",
+        "description": "Emitted when the tray balloon is clicked.",
+        "platforms": {}
+      },
+      "balloon-closed": {
+        "name": "balloon-closed",
+        "description": "Emitted when the tray balloon is closed because of timeout or user manually closes it.",
+        "platforms": {}
+      },
+      "drop": {
+        "name": "drop",
+        "description": "Emitted when any dragged items are dropped on the tray icon.",
+        "platforms": {}
+      },
+      "drop-files": {
+        "name": "drop-files",
+        "description": "Emitted when dragged files are dropped in the tray icon.",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "files": {
+            "name": "files",
+            "type": "String[]",
+            "description": "The paths of the dropped files."
+          }
+        }
+      },
+      "drop-text": {
+        "name": "drop-text",
+        "description": "Emitted when dragged text is dropped in the tray icon.",
+        "platforms": {},
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "text": {
+            "name": "text",
+            "type": "String",
+            "description": "the dropped text string"
+          }
+        }
+      },
+      "drag-enter": {
+        "name": "drag-enter",
+        "description": "Emitted when a drag operation enters the tray icon.",
+        "platforms": {}
+      },
+      "drag-leave": {
+        "name": "drag-leave",
+        "description": "Emitted when a drag operation exits the tray icon.",
+        "platforms": {}
+      },
+      "drag-end": {
+        "name": "drag-end",
+        "description": "Emitted when a drag operation ends on the tray or ends at another location.",
+        "platforms": {}
+      }
+    }
+  },
+  "webContents": {
+    "name": "webContents",
+    "description": "Render and control web pages.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Module",
+    "slug": "web-contents",
+    "websiteUrl": "http://electron.atom.io/docs/api/web-contents",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/web-contents.md",
+    "methods": {
+      "getAllWebContents": {
+        "name": "getAllWebContents",
+        "signature": "()",
+        "returns": {
+          "type": "WebContents[]",
+          "description": "An array of all WebContents instances. This will contain web contents for all windows, webviews, opened devtools, and devtools extension background pages."
+        }
+      },
+      "getFocusedWebContents": {
+        "name": "getFocusedWebContents",
+        "signature": "()",
+        "returns": {
+          "type": "WebContents",
+          "description": "The web contents that is focused in this application, otherwise returns null."
+        }
+      },
+      "fromId": {
+        "name": "fromId",
+        "signature": "(id)",
+        "parameters": {
+          "id": {
+            "name": "id",
+            "type": "Integer"
+          }
+        },
+        "returns": {
+          "type": "WebContents",
+          "description": "A WebContents instance with the given ID."
+        }
+      }
+    }
+  },
+  "WebContents": {
+    "name": "WebContents",
+    "description": "Render and control the contents of a BrowserWindow instance.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Class",
+    "slug": "web-contents",
+    "websiteUrl": "http://electron.atom.io/docs/api/web-contents",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/web-contents.md",
+    "instanceName": "contents",
+    "instanceMethods": {
+      "loadURL": {
+        "name": "loadURL",
+        "signature": "(url[, options])",
+        "description": "Loads the url in the window. The url must contain the protocol prefix, e.g. the http:// or file://. If the load should bypass http cache then use the pragma header to achieve it.",
+        "parameters": {
+          "url": {
+            "name": "url",
+            "type": "URL"
+          },
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "description": "(optional)",
+            "properties": {
+              "httpReferrer": {
+                "name": "httpReferrer",
+                "type": "String",
+                "description": "A HTTP Referrer url."
+              },
+              "userAgent": {
+                "name": "userAgent",
+                "type": "String",
+                "description": "A user agent originating the request."
+              },
+              "extraHeaders": {
+                "name": "extraHeaders",
+                "type": "String",
+                "description": "Extra headers separated by \"\\n\""
+              }
+            }
+          }
+        }
+      },
+      "downloadURL": {
+        "name": "downloadURL",
+        "signature": "(url)",
+        "description": "Initiates a download of the resource at url without navigating. The will-download event of session will be triggered.",
+        "parameters": {
+          "url": {
+            "name": "url",
+            "type": "String"
+          }
+        }
+      },
+      "getURL": {
+        "name": "getURL",
+        "signature": "()",
+        "returns": {
+          "type": "String",
+          "description": "The URL of the current web page."
+        }
+      },
+      "getTitle": {
+        "name": "getTitle",
+        "signature": "()",
+        "returns": {
+          "type": "String",
+          "description": "The title of the current web page."
+        }
+      },
+      "isDestroyed": {
+        "name": "isDestroyed",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the web page is destroyed."
+        }
+      },
+      "isFocused": {
+        "name": "isFocused",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the web page is focused."
+        }
+      },
+      "isLoading": {
+        "name": "isLoading",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether web page is still loading resources."
+        }
+      },
+      "isLoadingMainFrame": {
+        "name": "isLoadingMainFrame",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the main frame (and not just iframes or frames within it) is still loading."
+        }
+      },
+      "isWaitingForResponse": {
+        "name": "isWaitingForResponse",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the web page is waiting for a first-response from the main resource of the page."
+        }
+      },
+      "stop": {
+        "name": "stop",
+        "signature": "()",
+        "description": "Stops any pending navigation."
+      },
+      "reload": {
+        "name": "reload",
+        "signature": "()",
+        "description": "Reloads the current web page."
+      },
+      "reloadIgnoringCache": {
+        "name": "reloadIgnoringCache",
+        "signature": "()",
+        "description": "Reloads current page and ignores cache."
+      },
+      "canGoBack": {
+        "name": "canGoBack",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the browser can go back to previous web page."
+        }
+      },
+      "canGoForward": {
+        "name": "canGoForward",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the browser can go forward to next web page."
+        }
+      },
+      "canGoToOffset": {
+        "name": "canGoToOffset",
+        "signature": "(offset)",
+        "parameters": {
+          "offset": {
+            "name": "offset",
+            "type": "Integer"
+          }
+        },
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the web page can go to offset."
+        }
+      },
+      "clearHistory": {
+        "name": "clearHistory",
+        "signature": "()",
+        "description": "Clears the navigation history."
+      },
+      "goBack": {
+        "name": "goBack",
+        "signature": "()",
+        "description": "Makes the browser go back a web page."
+      },
+      "goForward": {
+        "name": "goForward",
+        "signature": "()",
+        "description": "Makes the browser go forward a web page."
+      },
+      "goToIndex": {
+        "name": "goToIndex",
+        "signature": "(index)",
+        "description": "Navigates browser to the specified absolute web page index.",
+        "parameters": {
+          "index": {
+            "name": "index",
+            "type": "Integer"
+          }
+        }
+      },
+      "goToOffset": {
+        "name": "goToOffset",
+        "signature": "(offset)",
+        "description": "Navigates to the specified offset from the \"current entry\".",
+        "parameters": {
+          "offset": {
+            "name": "offset",
+            "type": "Integer"
+          }
+        }
+      },
+      "isCrashed": {
+        "name": "isCrashed",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the renderer process has crashed."
+        }
+      },
+      "setUserAgent": {
+        "name": "setUserAgent",
+        "signature": "(userAgent)",
+        "description": "Overrides the user agent for this web page.",
+        "parameters": {
+          "userAgent": {
+            "name": "userAgent",
+            "type": "String"
+          }
+        }
+      },
+      "getUserAgent": {
+        "name": "getUserAgent",
+        "signature": "()",
+        "returns": {
+          "type": "String",
+          "description": "The user agent for this web page."
+        }
+      },
+      "insertCSS": {
+        "name": "insertCSS",
+        "signature": "(css)",
+        "description": "Injects CSS into the current web page.",
+        "parameters": {
+          "css": {
+            "name": "css",
+            "type": "String"
+          }
+        }
+      },
+      "executeJavaScript": {
+        "name": "executeJavaScript",
+        "signature": "(code[, userGesture, callback])",
+        "description": "Evaluates code in page. In the browser window some HTML APIs like requestFullScreen can only be invoked by a gesture from the user. Setting userGesture to true will remove this limitation.",
+        "parameters": {
+          "code": {
+            "name": "code",
+            "type": "String"
+          },
+          "userGesture": {
+            "name": "userGesture",
+            "type": "Boolean",
+            "description": "(optional)"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function",
+            "description": "(optional) - Called after script has been executed."
+          }
+        }
+      },
+      "setAudioMuted": {
+        "name": "setAudioMuted",
+        "signature": "(muted)",
+        "description": "Mute the audio on the current web page.",
+        "parameters": {
+          "muted": {
+            "name": "muted",
+            "type": "Boolean"
+          }
+        }
+      },
+      "isAudioMuted": {
+        "name": "isAudioMuted",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether this page has been muted."
+        }
+      },
+      "setZoomFactor": {
+        "name": "setZoomFactor",
+        "signature": "(factor)",
+        "description": "Changes the zoom factor to the specified factor. Zoom factor is zoom percent divided by 100, so 300% = 3.0.",
+        "parameters": {
+          "factor": {
+            "name": "factor",
+            "type": "Number",
+            "description": "Zoom factor."
+          }
+        }
+      },
+      "getZoomFactor": {
+        "name": "getZoomFactor",
+        "signature": "(callback)",
+        "description": "Sends a request to get current zoom factor, the callback will be called with callback(zoomFactor).",
+        "parameters": {
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "setZoomLevel": {
+        "name": "setZoomLevel",
+        "signature": "(level)",
+        "description": "Changes the zoom level to the specified level. The original size is 0 and each increment above or below represents zooming 20% larger or smaller to default limits of 300% and 50% of original size, respectively.",
+        "parameters": {
+          "level": {
+            "name": "level",
+            "type": "Number",
+            "description": "Zoom level"
+          }
+        }
+      },
+      "getZoomLevel": {
+        "name": "getZoomLevel",
+        "signature": "(callback)",
+        "description": "Sends a request to get current zoom level, the callback will be called with callback(zoomLevel).",
+        "parameters": {
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "setZoomLevelLimits": {
+        "name": "setZoomLevelLimits",
+        "signature": "(minimumLevel, maximumLevel)",
+        "description": "Sets the maximum and minimum zoom level.",
+        "parameters": {
+          "minimumLevel": {
+            "name": "minimumLevel",
+            "type": "Number"
+          },
+          "maximumLevel": {
+            "name": "maximumLevel",
+            "type": "Number"
+          }
+        }
+      },
+      "undo": {
+        "name": "undo",
+        "signature": "()",
+        "description": "Executes the editing command undo in web page."
+      },
+      "redo": {
+        "name": "redo",
+        "signature": "()",
+        "description": "Executes the editing command redo in web page."
+      },
+      "cut": {
+        "name": "cut",
+        "signature": "()",
+        "description": "Executes the editing command cut in web page."
+      },
+      "copy": {
+        "name": "copy",
+        "signature": "()",
+        "description": "Executes the editing command copy in web page."
+      },
+      "copyImageAt": {
+        "name": "copyImageAt",
+        "signature": "(x, y)",
+        "description": "Copy the image at the given position to the clipboard.",
+        "parameters": {
+          "x": {
+            "name": "x",
+            "type": "Integer"
+          },
+          "y": {
+            "name": "y",
+            "type": "Integer"
+          }
+        }
+      },
+      "paste": {
+        "name": "paste",
+        "signature": "()",
+        "description": "Executes the editing command paste in web page."
+      },
+      "pasteAndMatchStyle": {
+        "name": "pasteAndMatchStyle",
+        "signature": "()",
+        "description": "Executes the editing command pasteAndMatchStyle in web page."
+      },
+      "delete": {
+        "name": "delete",
+        "signature": "()",
+        "description": "Executes the editing command delete in web page."
+      },
+      "selectAll": {
+        "name": "selectAll",
+        "signature": "()",
+        "description": "Executes the editing command selectAll in web page."
+      },
+      "unselect": {
+        "name": "unselect",
+        "signature": "()",
+        "description": "Executes the editing command unselect in web page."
+      },
+      "replace": {
+        "name": "replace",
+        "signature": "(text)",
+        "description": "Executes the editing command replace in web page.",
+        "parameters": {
+          "text": {
+            "name": "text",
+            "type": "String"
+          }
+        }
+      },
+      "replaceMisspelling": {
+        "name": "replaceMisspelling",
+        "signature": "(text)",
+        "description": "Executes the editing command replaceMisspelling in web page.",
+        "parameters": {
+          "text": {
+            "name": "text",
+            "type": "String"
+          }
+        }
+      },
+      "insertText": {
+        "name": "insertText",
+        "signature": "(text)",
+        "description": "Inserts text to the focused element.",
+        "parameters": {
+          "text": {
+            "name": "text",
+            "type": "String"
+          }
+        }
+      },
+      "findInPage": {
+        "name": "findInPage",
+        "signature": "(text[, options])",
+        "description": "Starts a request to find all matches for the text in the web page and returns an Integer representing the request id used for the request. The result of the request can be obtained by subscribing to found-in-page event.",
+        "parameters": {
+          "text": {
+            "name": "text",
+            "type": "String",
+            "description": "Content to be searched, must not be empty."
+          },
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "description": "(optional)",
+            "properties": {
+              "forward": {
+                "name": "forward",
+                "type": "Boolean",
+                "description": "Whether to search forward or backward, defaults to ."
+              },
+              "findNext": {
+                "name": "findNext",
+                "type": "Boolean",
+                "description": "Whether the operation is first request or a follow up, defaults to ."
+              },
+              "matchCase": {
+                "name": "matchCase",
+                "type": "Boolean",
+                "description": "Whether search should be case-sensitive, defaults to ."
+              },
+              "wordStart": {
+                "name": "wordStart",
+                "type": "Boolean",
+                "description": "Whether to look only at the start of words. defaults to ."
+              },
+              "medialCapitalAsWordStart": {
+                "name": "medialCapitalAsWordStart",
+                "type": "Boolean",
+                "description": "When combined with , accepts a match in the middle of a word if the match begins with an uppercase letter followed by a lowercase or non-letter. Accepts several other intra-word matches, defaults to ."
+              }
+            }
+          }
+        }
+      },
+      "stopFindInPage": {
+        "name": "stopFindInPage",
+        "signature": "(action)",
+        "description": "Stops any findInPage request for the webContents with the provided action.",
+        "parameters": {
+          "action": {
+            "name": "action",
+            "type": "String",
+            "description": "Specifies the action to take place when ending request.",
+            "possibleValues": {}
+          }
+        }
+      },
+      "capturePage": {
+        "name": "capturePage",
+        "signature": "([rect, ]callback)",
+        "description": "Captures a snapshot of the page within rect. Upon completion callback will be called with callback(image). The image is an instance of NativeImage that stores data of the snapshot. Omitting rect will capture the whole visible page.",
+        "parameters": {
+          "rect": {
+            "name": "rect",
+            "type": "Rectangle",
+            "description": "(optional) - The area of the page to be captured"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "hasServiceWorker": {
+        "name": "hasServiceWorker",
+        "signature": "(callback)",
+        "description": "Checks if any ServiceWorker is registered and returns a boolean as response to callback.",
+        "parameters": {
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "unregisterServiceWorker": {
+        "name": "unregisterServiceWorker",
+        "signature": "(callback)",
+        "description": "Unregisters any ServiceWorker if present and returns a boolean as response to callback when the JS promise is fulfilled or false when the JS promise is rejected.",
+        "parameters": {
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "print": {
+        "name": "print",
+        "signature": "([options])",
+        "description": "Prints window's web page. When silent is set to true, Electron will pick up system's default printer and default settings for printing. Calling window.print() in web page is equivalent to calling webContents.print({silent: false, printBackground: false}). Use page-break-before: always; CSS style to force to print to a new page.",
+        "parameters": {
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "description": "(optional)",
+            "properties": {
+              "silent": {
+                "name": "silent",
+                "type": "Boolean",
+                "description": "Don't ask user for print settings. Default is ."
+              },
+              "printBackground": {
+                "name": "printBackground",
+                "type": "Boolean",
+                "description": "Also prints the background color and image of the web page. Default is ."
+              }
+            }
+          }
+        }
+      },
+      "printToPDF": {
+        "name": "printToPDF",
+        "signature": "(options, callback)",
+        "description": "Prints window's web page as PDF with Chromium's preview printing custom settings. The callback will be called with callback(error, data) on completion. The data is a Buffer that contains the generated PDF data. By default, an empty options will be regarded as: Use page-break-before: always; CSS style to force to print to a new page. An example of webContents.printToPDF:",
+        "parameters": {
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "properties": {
+              "marginsType": {
+                "name": "marginsType",
+                "type": "Integer",
+                "description": "Specifies the type of margins to use. Uses 0 for default margin, 1 for no margin, and 2 for minimum margin."
+              },
+              "pageSize": {
+                "name": "pageSize",
+                "type": "String",
+                "description": "Specify page size of the generated PDF. Can be , , , , , or an Object containing and in microns."
+              },
+              "printBackground": {
+                "name": "printBackground",
+                "type": "Boolean",
+                "description": "Whether to print CSS backgrounds."
+              },
+              "printSelectionOnly": {
+                "name": "printSelectionOnly",
+                "type": "Boolean",
+                "description": "Whether to print selection only."
+              },
+              "landscape": {
+                "name": "landscape",
+                "type": "Boolean",
+                "description": "for landscape, for portrait."
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "addWorkSpace": {
+        "name": "addWorkSpace",
+        "signature": "(path)",
+        "description": "Adds the specified path to DevTools workspace. Must be used after DevTools creation:",
+        "parameters": {
+          "path": {
+            "name": "path",
+            "type": "String"
+          }
+        }
+      },
+      "removeWorkSpace": {
+        "name": "removeWorkSpace",
+        "signature": "(path)",
+        "description": "Removes the specified path from DevTools workspace.",
+        "parameters": {
+          "path": {
+            "name": "path",
+            "type": "String"
+          }
+        }
+      },
+      "openDevTools": {
+        "name": "openDevTools",
+        "signature": "([options])",
+        "description": "Opens the devtools.",
+        "parameters": {
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "description": "(optional)",
+            "properties": {
+              "mode": {
+                "name": "mode",
+                "type": "String",
+                "description": "Opens the devtools with specified dock state, can be , , , . Defaults to last used dock state. In mode it's possible to dock back. In mode it's not."
+              }
+            }
+          }
+        }
+      },
+      "closeDevTools": {
+        "name": "closeDevTools",
+        "signature": "()",
+        "description": "Closes the devtools."
+      },
+      "isDevToolsOpened": {
+        "name": "isDevToolsOpened",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the devtools is opened."
+        }
+      },
+      "isDevToolsFocused": {
+        "name": "isDevToolsFocused",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether the devtools view is focused ."
+        }
+      },
+      "toggleDevTools": {
+        "name": "toggleDevTools",
+        "signature": "()",
+        "description": "Toggles the developer tools."
+      },
+      "inspectElement": {
+        "name": "inspectElement",
+        "signature": "(x, y)",
+        "description": "Starts inspecting element at position (x, y).",
+        "parameters": {
+          "x": {
+            "name": "x",
+            "type": "Integer"
+          },
+          "y": {
+            "name": "y",
+            "type": "Integer"
+          }
+        }
+      },
+      "inspectServiceWorker": {
+        "name": "inspectServiceWorker",
+        "signature": "()",
+        "description": "Opens the developer tools for the service worker context."
+      },
+      "send": {
+        "name": "send",
+        "signature": "(channel[, arg1][, arg2][, ...])",
+        "description": "Send an asynchronous message to renderer process via channel, you can also send arbitrary arguments. Arguments will be serialized in JSON internally and hence no functions or prototype chain will be included. The renderer process can handle the message by listening to channel with the ipcRenderer module. An example of sending messages from the main process to the renderer process:",
+        "parameters": {
+          "channel": {
+            "name": "channel",
+            "type": "String"
+          }
+        }
+      },
+      "enableDeviceEmulation": {
+        "name": "enableDeviceEmulation",
+        "signature": "(parameters)",
+        "description": "Enable device emulation with the given parameters.",
+        "parameters": {
+          "parameters": {
+            "name": "parameters",
+            "type": "Object",
+            "properties": {
+              "screenPosition": {
+                "name": "screenPosition",
+                "type": "String",
+                "description": "Specify the screen type to emulate (default: )"
+              },
+              "screenSize": {
+                "name": "screenSize",
+                "type": "Object",
+                "description": "Set the emulated screen size (screenPosition == mobile)",
+                "properties": {
+                  "width": {
+                    "name": "width",
+                    "type": "Integer",
+                    "description": "Set the emulated screen width"
+                  },
+                  "height": {
+                    "name": "height",
+                    "type": "Integer",
+                    "description": "Set the emulated screen height"
+                  }
+                }
+              },
+              "viewPosition": {
+                "name": "viewPosition",
+                "type": "Object",
+                "description": "Position the view on the screen (screenPosition == mobile) (default: )",
+                "properties": {
+                  "x": {
+                    "name": "x",
+                    "type": "Integer",
+                    "description": "Set the x axis offset from top left corner"
+                  },
+                  "y": {
+                    "name": "y",
+                    "type": "Integer",
+                    "description": "Set the y axis offset from top left corner"
+                  }
+                }
+              },
+              "deviceScaleFactor": {
+                "name": "deviceScaleFactor",
+                "type": "Integer",
+                "description": "Set the device scale factor (if zero defaults to original device scale factor) (default: )"
+              },
+              "viewSize": {
+                "name": "viewSize",
+                "type": "Object",
+                "description": "Set the emulated view size (empty means no override)",
+                "properties": {
+                  "width": {
+                    "name": "width",
+                    "type": "Integer",
+                    "description": "Set the emulated view width"
+                  },
+                  "height": {
+                    "name": "height",
+                    "type": "Integer",
+                    "description": "Set the emulated view height"
+                  }
+                }
+              },
+              "fitToView": {
+                "name": "fitToView",
+                "type": "Boolean",
+                "description": "Whether emulated view should be scaled down if necessary to fit into available space (default: )"
+              },
+              "offset": {
+                "name": "offset",
+                "type": "Object",
+                "description": "Offset of the emulated view inside available space (not in fit to view mode) (default: )",
+                "properties": {
+                  "x": {
+                    "name": "x",
+                    "type": "Float",
+                    "description": "Set the x axis offset from top left corner"
+                  },
+                  "y": {
+                    "name": "y",
+                    "type": "Float",
+                    "description": "Set the y axis offset from top left corner"
+                  }
+                }
+              },
+              "scale": {
+                "name": "scale",
+                "type": "Float",
+                "description": "Scale of emulated view inside available space (not in fit to view mode) (default: )"
+              }
+            }
+          }
+        }
+      },
+      "disableDeviceEmulation": {
+        "name": "disableDeviceEmulation",
+        "signature": "()",
+        "description": "Disable device emulation enabled by webContents.enableDeviceEmulation."
+      },
+      "sendInputEvent": {
+        "name": "sendInputEvent",
+        "signature": "(event)",
+        "description": "Sends an input event to the page. For keyboard events, the event object also have following properties: For mouse events, the event object also have following properties: For the mouseWheel event, the event object also have following properties:",
+        "parameters": {
+          "event": {
+            "name": "event",
+            "type": "Object",
+            "properties": {
+              "type": {
+                "name": "type",
+                "type": "String",
+                "description": "() - The type of the event, can be , , , , , , , , , ."
+              },
+              "modifiers": {
+                "name": "modifiers",
+                "type": "String[]",
+                "description": "An array of modifiers of the event, can include , , , , , , , , , , , , ."
+              }
+            }
+          }
+        }
+      },
+      "beginFrameSubscription": {
+        "name": "beginFrameSubscription",
+        "signature": "([onlyDirty ,]callback)",
+        "description": "Begin subscribing for presentation events and captured frames, the callback will be called with callback(frameBuffer, dirtyRect) when there is a presentation event. The frameBuffer is a Buffer that contains raw pixel data. On most machines, the pixel data is effectively stored in 32bit BGRA format, but the actual representation depends on the endianness of the processor (most modern processors are little-endian, on machines with big-endian processors the data is in 32bit ARGB format). The dirtyRect is an object with x, y, width, height properties that describes which part of the page was repainted. If onlyDirty is set to true, frameBuffer will only contain the repainted area. onlyDirty defaults to false.",
+        "parameters": {
+          "onlyDirty": {
+            "name": "onlyDirty",
+            "type": "Boolean",
+            "description": "(optional) - Defaults to `false`"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "endFrameSubscription": {
+        "name": "endFrameSubscription",
+        "signature": "()",
+        "description": "End subscribing for frame presentation events."
+      },
+      "startDrag": {
+        "name": "startDrag",
+        "signature": "(item)",
+        "description": "Sets the item as dragging item for current drag-drop operation, file is the absolute path of the file to be dragged, and icon is the image showing under the cursor when dragging.",
+        "parameters": {
+          "item": {
+            "name": "item",
+            "type": "object"
+          }
+        }
+      },
+      "savePage": {
+        "name": "savePage",
+        "signature": "(fullPath, saveType, callback)",
+        "description": "Returns true if the process of saving page has been initiated successfully.",
+        "parameters": {
+          "fullPath": {
+            "name": "fullPath",
+            "type": "String",
+            "description": "The full file path."
+          },
+          "saveType": {
+            "name": "saveType",
+            "type": "String",
+            "description": "Specify the save type.",
+            "possibleValues": {}
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function",
+            "description": "`(error) => {}`."
+          }
+        }
+      },
+      "showDefinitionForSelection": {
+        "name": "showDefinitionForSelection",
+        "signature": "()",
+        "platforms": {},
+        "description": "Shows pop-up dictionary that searches the selected word on the page."
+      },
+      "isOffscreen": {
+        "name": "isOffscreen",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Indicates whether offscreen rendering is enabled."
+        }
+      },
+      "startPainting": {
+        "name": "startPainting",
+        "signature": "()",
+        "description": "If offscreen rendering is enabled and not painting, start painting."
+      },
+      "stopPainting": {
+        "name": "stopPainting",
+        "signature": "()",
+        "description": "If offscreen rendering is enabled and painting, stop painting."
+      },
+      "isPainting": {
+        "name": "isPainting",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "If offscreen rendering is enabled returns whether it is currently painting."
+        }
+      },
+      "setFrameRate": {
+        "name": "setFrameRate",
+        "signature": "(fps)",
+        "description": "If offscreen rendering is enabled sets the frame rate to the specified number. Only values between 1 and 60 are accepted.",
+        "parameters": {
+          "fps": {
+            "name": "fps",
+            "type": "Integer"
+          }
+        }
+      },
+      "getFrameRate": {
+        "name": "getFrameRate",
+        "signature": "()",
+        "returns": {
+          "type": "Integer",
+          "description": "If offscreen rendering is enabled returns the current frame rate."
+        }
+      },
+      "invalidate": {
+        "name": "invalidate",
+        "signature": "()",
+        "description": "If offscreen rendering is enabled invalidates the frame and generates a new one through the 'paint' event."
+      }
+    },
+    "instanceProperties": {
+      "id": {
+        "name": "id",
+        "description": "A Integer representing the unique ID of this WebContents."
+      },
+      "session": {
+        "name": "session",
+        "description": "A Session object (session) used by this webContents."
+      },
+      "hostWebContents": {
+        "name": "hostWebContents",
+        "description": "A WebContents that might own this WebContents."
+      },
+      "devToolsWebContents": {
+        "name": "devToolsWebContents",
+        "description": "A WebContents of DevTools for this WebContents. Note: Users should never store this object because it may become null when the DevTools has been closed."
+      },
+      "debugger": {
+        "name": "debugger",
+        "description": "A Debugger instance for this webContents."
+      }
+    },
+    "instanceEvents": {
+      "did-finish-load": {
+        "name": "did-finish-load",
+        "description": "Emitted when the navigation is done, i.e. the spinner of the tab has stopped spinning, and the onload event was dispatched."
+      },
+      "did-fail-load": {
+        "name": "did-fail-load",
+        "description": "This event is like did-finish-load but emitted when the load failed or was cancelled, e.g. window.stop() is invoked. The full list of error codes and their meaning is available here. Note that redirect responses will emit errorCode -3; you may want to ignore that error explicitly.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "errorCode": {
+            "name": "errorCode",
+            "type": "Integer"
+          },
+          "errorDescription": {
+            "name": "errorDescription",
+            "type": "String"
+          },
+          "validatedURL": {
+            "name": "validatedURL",
+            "type": "String"
+          },
+          "isMainFrame": {
+            "name": "isMainFrame",
+            "type": "Boolean"
+          }
+        }
+      },
+      "did-frame-finish-load": {
+        "name": "did-frame-finish-load",
+        "description": "Emitted when a frame has done navigation.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "isMainFrame": {
+            "name": "isMainFrame",
+            "type": "Boolean"
+          }
+        }
+      },
+      "did-start-loading": {
+        "name": "did-start-loading",
+        "description": "Corresponds to the points in time when the spinner of the tab started spinning."
+      },
+      "did-stop-loading": {
+        "name": "did-stop-loading",
+        "description": "Corresponds to the points in time when the spinner of the tab stopped spinning."
+      },
+      "did-get-response-details": {
+        "name": "did-get-response-details",
+        "description": "Emitted when details regarding a requested resource are available. status indicates the socket connection to download the resource.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "status": {
+            "name": "status",
+            "type": "Boolean"
+          },
+          "newURL": {
+            "name": "newURL",
+            "type": "String"
+          },
+          "originalURL": {
+            "name": "originalURL",
+            "type": "String"
+          },
+          "httpResponseCode": {
+            "name": "httpResponseCode",
+            "type": "Integer"
+          },
+          "requestMethod": {
+            "name": "requestMethod",
+            "type": "String"
+          },
+          "referrer": {
+            "name": "referrer",
+            "type": "String"
+          },
+          "headers": {
+            "name": "headers",
+            "type": "Object"
+          },
+          "resourceType": {
+            "name": "resourceType",
+            "type": "String"
+          }
+        }
+      },
+      "did-get-redirect-request": {
+        "name": "did-get-redirect-request",
+        "description": "Emitted when a redirect is received while requesting a resource.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "oldURL": {
+            "name": "oldURL",
+            "type": "String"
+          },
+          "newURL": {
+            "name": "newURL",
+            "type": "String"
+          },
+          "isMainFrame": {
+            "name": "isMainFrame",
+            "type": "Boolean"
+          },
+          "httpResponseCode": {
+            "name": "httpResponseCode",
+            "type": "Integer"
+          },
+          "requestMethod": {
+            "name": "requestMethod",
+            "type": "String"
+          },
+          "referrer": {
+            "name": "referrer",
+            "type": "String"
+          },
+          "headers": {
+            "name": "headers",
+            "type": "Object"
+          }
+        }
+      },
+      "dom-ready": {
+        "name": "dom-ready",
+        "description": "Emitted when the document in the given frame is loaded.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          }
+        }
+      },
+      "page-favicon-updated": {
+        "name": "page-favicon-updated",
+        "description": "Emitted when page receives favicon urls.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "favicons": {
+            "name": "favicons",
+            "type": "String[]",
+            "description": "Array of URLs"
+          }
+        }
+      },
+      "new-window": {
+        "name": "new-window",
+        "description": "Emitted when the page requests to open a new window for a url. It could be requested by window.open or an external link like <a target='_blank'>. By default a new BrowserWindow will be created for the url. Calling event.preventDefault() will prevent creating new windows. In such case, the event.newGuest may be set with a reference to a BrowserWindow instance to make it used by the Electron's runtime.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "url": {
+            "name": "url",
+            "type": "String"
+          },
+          "frameName": {
+            "name": "frameName",
+            "type": "String"
+          },
+          "disposition": {
+            "name": "disposition",
+            "type": "String",
+            "description": "Can be `default`, `foreground-tab`, `background-tab`, `new-window`, `save-to-disk` and `other`."
+          },
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "description": "The options which will be used for creating the new `BrowserWindow`."
+          },
+          "additionalFeatures": {
+            "name": "additionalFeatures",
+            "type": "Array",
+            "description": "The non-standard features (features not handled by Chromium or Electron) given to `window.open()`."
+          }
+        }
+      },
+      "will-navigate": {
+        "name": "will-navigate",
+        "description": "Emitted when a user or the page wants to start navigation. It can happen when the window.location object is changed or a user clicks a link in the page. This event will not emit when the navigation is started programmatically with APIs like webContents.loadURL and webContents.back. It is also not emitted for in-page navigations, such as clicking anchor links or updating the window.location.hash. Use did-navigate-in-page event for this purpose. Calling event.preventDefault() will prevent the navigation.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "url": {
+            "name": "url",
+            "type": "String"
+          }
+        }
+      },
+      "did-navigate": {
+        "name": "did-navigate",
+        "description": "Emitted when a navigation is done. This event is not emitted for in-page navigations, such as clicking anchor links or updating the window.location.hash. Use did-navigate-in-page event for this purpose.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "url": {
+            "name": "url",
+            "type": "String"
+          }
+        }
+      },
+      "did-navigate-in-page": {
+        "name": "did-navigate-in-page",
+        "description": "Emitted when an in-page navigation happened. When in-page navigation happens, the page URL changes but does not cause navigation outside of the page. Examples of this occurring are when anchor links are clicked or when the DOM hashchange event is triggered.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "url": {
+            "name": "url",
+            "type": "String"
+          },
+          "isMainFrame": {
+            "name": "isMainFrame",
+            "type": "Boolean"
+          }
+        }
+      },
+      "crashed": {
+        "name": "crashed",
+        "description": "Emitted when the renderer process crashes or is killed.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "killed": {
+            "name": "killed",
+            "type": "Boolean"
+          }
+        }
+      },
+      "plugin-crashed": {
+        "name": "plugin-crashed",
+        "description": "Emitted when a plugin process has crashed.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "name": {
+            "name": "name",
+            "type": "String"
+          },
+          "version": {
+            "name": "version",
+            "type": "String"
+          }
+        }
+      },
+      "destroyed": {
+        "name": "destroyed",
+        "description": "Emitted when webContents is destroyed."
+      },
+      "devtools-opened": {
+        "name": "devtools-opened",
+        "description": "Emitted when DevTools is opened."
+      },
+      "devtools-closed": {
+        "name": "devtools-closed",
+        "description": "Emitted when DevTools is closed."
+      },
+      "devtools-focused": {
+        "name": "devtools-focused",
+        "description": "Emitted when DevTools is focused / opened."
+      },
+      "certificate-error": {
+        "name": "certificate-error",
+        "description": "Emitted when failed to verify the certificate for url. The usage is the same with the certificate-error event of app.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "url": {
+            "name": "url",
+            "type": "URL"
+          },
+          "error": {
+            "name": "error",
+            "type": "String",
+            "description": "The error code"
+          },
+          "certificate": {
+            "name": "certificate",
+            "type": "Certificate"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "select-client-certificate": {
+        "name": "select-client-certificate",
+        "description": "Emitted when a client certificate is requested. The usage is the same with the select-client-certificate event of app.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "url": {
+            "name": "url",
+            "type": "URL"
+          },
+          "certificateList": {
+            "name": "certificateList",
+            "type": "Certificate[]"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "login": {
+        "name": "login",
+        "description": "Emitted when webContents wants to do basic auth. The usage is the same with the login event of app.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "request": {
+            "name": "request",
+            "type": "Object",
+            "properties": {
+              "method": {
+                "name": "method",
+                "type": "String",
+                "description": ""
+              },
+              "url": {
+                "name": "url",
+                "type": "URL",
+                "description": ""
+              },
+              "referrer": {
+                "name": "referrer",
+                "type": "URL",
+                "description": ""
+              }
+            }
+          },
+          "authInfo": {
+            "name": "authInfo",
+            "type": "Object",
+            "properties": {
+              "isProxy": {
+                "name": "isProxy",
+                "type": "Boolean",
+                "description": ""
+              },
+              "scheme": {
+                "name": "scheme",
+                "type": "String",
+                "description": ""
+              },
+              "host": {
+                "name": "host",
+                "type": "String",
+                "description": ""
+              },
+              "port": {
+                "name": "port",
+                "type": "Integer",
+                "description": ""
+              },
+              "realm": {
+                "name": "realm",
+                "type": "String",
+                "description": ""
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "found-in-page": {
+        "name": "found-in-page",
+        "description": "Emitted when a result is available for webContents.findInPage request.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "result": {
+            "name": "result",
+            "type": "Object",
+            "properties": {
+              "requestId": {
+                "name": "requestId",
+                "type": "Integer",
+                "description": ""
+              },
+              "activeMatchOrdinal": {
+                "name": "activeMatchOrdinal",
+                "type": "Integer",
+                "description": "Position of the active match."
+              },
+              "matches": {
+                "name": "matches",
+                "type": "Integer",
+                "description": "Number of Matches."
+              },
+              "selectionArea": {
+                "name": "selectionArea",
+                "type": "Object",
+                "description": "Coordinates of first match region.",
+                "properties": {}
+              }
+            }
+          }
+        }
+      },
+      "media-started-playing": {
+        "name": "media-started-playing",
+        "description": "Emitted when media starts playing."
+      },
+      "media-paused": {
+        "name": "media-paused",
+        "description": "Emitted when media is paused or done playing."
+      },
+      "did-change-theme-color": {
+        "name": "did-change-theme-color",
+        "description": "Emitted when a page's theme color changes. This is usually due to encountering a meta tag:"
+      },
+      "update-target-url": {
+        "name": "update-target-url",
+        "description": "Emitted when mouse moves over a link or the keyboard moves the focus to a link.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "url": {
+            "name": "url",
+            "type": "String"
+          }
+        }
+      },
+      "cursor-changed": {
+        "name": "cursor-changed",
+        "description": "Emitted when the cursor's type changes. The type parameter can be default, crosshair, pointer, text, wait, help, e-resize, n-resize, ne-resize, nw-resize, s-resize, se-resize, sw-resize, w-resize, ns-resize, ew-resize, nesw-resize, nwse-resize, col-resize, row-resize, m-panning, e-panning, n-panning, ne-panning, nw-panning, s-panning, se-panning, sw-panning, w-panning, move, vertical-text, cell, context-menu, alias, progress, nodrop, copy, none, not-allowed, zoom-in, zoom-out, grab, grabbing, custom. If the type parameter is custom, the image parameter will hold the custom cursor image in a NativeImage, and scale, size and hotspot will hold additional information about the custom cursor.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "type": {
+            "name": "type",
+            "type": "String"
+          },
+          "image": {
+            "name": "image",
+            "type": "NativeImage",
+            "description": "(optional)"
+          },
+          "scale": {
+            "name": "scale",
+            "type": "Float",
+            "description": "(optional) - scaling factor for the custom cursor"
+          },
+          "size": {
+            "name": "size",
+            "type": "Object",
+            "description": "(optional) - the size of the `image`",
+            "properties": {
+              "width": {
+                "name": "width",
+                "type": "Integer",
+                "description": ""
+              },
+              "height": {
+                "name": "height",
+                "type": "Integer",
+                "description": ""
+              }
+            }
+          },
+          "hotspot": {
+            "name": "hotspot",
+            "type": "Object",
+            "description": "(optional) - coordinates of the custom cursor's hotspot",
+            "properties": {
+              "x": {
+                "name": "x",
+                "type": "Integer",
+                "description": "x coordinate"
+              },
+              "y": {
+                "name": "y",
+                "type": "Integer",
+                "description": "y coordinate"
+              }
+            }
+          }
+        }
+      },
+      "context-menu": {
+        "name": "context-menu",
+        "description": "The mediaFlags is an object with the following properties: The editFlags is an object with the following properties: Emitted when there is a new context menu that needs to be handled.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "params": {
+            "name": "params",
+            "type": "Object",
+            "properties": {
+              "x": {
+                "name": "x",
+                "type": "Integer",
+                "description": "x coordinate"
+              },
+              "y": {
+                "name": "y",
+                "type": "Integer",
+                "description": "y coordinate"
+              },
+              "linkURL": {
+                "name": "linkURL",
+                "type": "String",
+                "description": "URL of the link that encloses the node the context menu was invoked on."
+              },
+              "linkText": {
+                "name": "linkText",
+                "type": "String",
+                "description": "Text associated with the link. May be an empty string if the contents of the link are an image."
+              },
+              "pageURL": {
+                "name": "pageURL",
+                "type": "String",
+                "description": "URL of the top level page that the context menu was invoked on."
+              },
+              "frameURL": {
+                "name": "frameURL",
+                "type": "String",
+                "description": "URL of the subframe that the context menu was invoked on."
+              },
+              "srcURL": {
+                "name": "srcURL",
+                "type": "String",
+                "description": "Source URL for the element that the context menu was invoked on. Elements with source URLs are images, audio and video."
+              },
+              "mediaType": {
+                "name": "mediaType",
+                "type": "String",
+                "description": "Type of the node the context menu was invoked on. Can be , , , , , or ."
+              },
+              "hasImageContents": {
+                "name": "hasImageContents",
+                "type": "Boolean",
+                "description": "Whether the context menu was invoked on an image which has non-empty contents."
+              },
+              "isEditable": {
+                "name": "isEditable",
+                "type": "Boolean",
+                "description": "Whether the context is editable."
+              },
+              "selectionText": {
+                "name": "selectionText",
+                "type": "String",
+                "description": "Text of the selection that the context menu was invoked on."
+              },
+              "titleText": {
+                "name": "titleText",
+                "type": "String",
+                "description": "Title or alt text of the selection that the context was invoked on."
+              },
+              "misspelledWord": {
+                "name": "misspelledWord",
+                "type": "String",
+                "description": "The misspelled word under the cursor, if any."
+              },
+              "frameCharset": {
+                "name": "frameCharset",
+                "type": "String",
+                "description": "The character encoding of the frame on which the menu was invoked."
+              },
+              "inputFieldType": {
+                "name": "inputFieldType",
+                "type": "String",
+                "description": "If the context menu was invoked on an input field, the type of that field. Possible values are , , , ."
+              },
+              "menuSourceType": {
+                "name": "menuSourceType",
+                "type": "String",
+                "description": "Input source that invoked the context menu. Can be , , , , ."
+              },
+              "mediaFlags": {
+                "name": "mediaFlags",
+                "type": "Object",
+                "description": "The flags for the media element the context menu was invoked on. See more about this below.",
+                "properties": {}
+              },
+              "editFlags": {
+                "name": "editFlags",
+                "type": "Object",
+                "description": "These flags indicate whether the renderer believes it is able to perform the corresponding action. See more about this below.",
+                "properties": {}
+              }
+            }
+          }
+        }
+      },
+      "select-bluetooth-device": {
+        "name": "select-bluetooth-device",
+        "description": "Emitted when bluetooth device needs to be selected on call to navigator.bluetooth.requestDevice. To use navigator.bluetooth api webBluetooth should be enabled.  If event.preventDefault is not called, first available device will be selected. callback should be called with deviceId to be selected, passing empty string to callback will cancel the request.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "devices": {
+            "name": "devices",
+            "type": "[Objects]"
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      },
+      "paint": {
+        "name": "paint",
+        "description": "Emitted when a new frame is generated. Only the dirty area is passed in the buffer.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "dirtyRect": {
+            "name": "dirtyRect",
+            "type": "Rectangle"
+          },
+          "image": {
+            "name": "image",
+            "type": "NativeImage",
+            "description": "The image data of the whole frame."
+          }
+        }
+      }
+    }
+  },
+  "Debugger": {
+    "name": "Debugger",
+    "description": "An alternate transport for Chrome's remote debugging protocol.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Class",
+    "slug": "debugger",
+    "websiteUrl": "http://electron.atom.io/docs/api/debugger",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/debugger.md",
+    "instanceName": "debugger",
+    "instanceMethods": {
+      "attach": {
+        "name": "attach",
+        "signature": "([protocolVersion])",
+        "description": "Attaches the debugger to the webContents.",
+        "parameters": {
+          "protocolVersion": {
+            "name": "protocolVersion",
+            "type": "String",
+            "description": "(optional) - Requested debugging protocol version."
+          }
+        }
+      },
+      "isAttached": {
+        "name": "isAttached",
+        "signature": "()",
+        "returns": {
+          "type": "Boolean",
+          "description": "Whether a debugger is attached to the webContents."
+        }
+      },
+      "detach": {
+        "name": "detach",
+        "signature": "()",
+        "description": "Detaches the debugger from the webContents."
+      },
+      "sendCommand": {
+        "name": "sendCommand",
+        "signature": "(method[, commandParams, callback])",
+        "description": "Send given command to the debugging target.",
+        "parameters": {
+          "method": {
+            "name": "method",
+            "type": "String",
+            "description": "Method name, should be one of the methods defined by the remote debugging protocol."
+          },
+          "commandParams": {
+            "name": "commandParams",
+            "type": "Object",
+            "description": "(optional) - JSON object with request parameters."
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function",
+            "description": "(optional) - Response"
+          }
+        }
+      }
+    },
+    "instanceEvents": {
+      "detach": {
+        "name": "detach",
+        "description": "Emitted when debugging session is terminated. This happens either when webContents is closed or devtools is invoked for the attached webContents.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "reason": {
+            "name": "reason",
+            "type": "String",
+            "description": "Reason for detaching debugger."
+          }
+        }
+      },
+      "message": {
+        "name": "message",
+        "description": "Emitted whenever debugging target issues instrumentation event.",
+        "returns": {
+          "event": {
+            "name": "event",
+            "type": "Event"
+          },
+          "method": {
+            "name": "method",
+            "type": "String",
+            "description": "Method name."
+          },
+          "params": {
+            "name": "params",
+            "type": "Object",
+            "description": "Event parameters defined by the 'parameters' attribute in the remote debugging protocol."
+          }
+        }
+      }
+    }
+  },
+  "process": {
+    "name": "process",
+    "description": "Extensions to process object.",
+    "process": {
+      "main": true,
+      "renderer": false
+    },
+    "type": "Module",
+    "slug": "process",
+    "websiteUrl": "http://electron.atom.io/docs/api/process",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/process.md",
+    "methods": {
+      "crash": {
+        "name": "crash",
+        "signature": "()",
+        "description": "Causes the main thread of the current process crash."
+      },
+      "hang": {
+        "name": "hang",
+        "signature": "()",
+        "description": "Causes the main thread of the current process hang."
+      },
+      "setFdLimit": {
+        "name": "setFdLimit",
+        "signature": "(maxDescriptors)",
+        "platforms": {},
+        "description": "Sets the file descriptor soft limit to maxDescriptors or the OS hard limit, whichever is lower for the current process.",
+        "parameters": {
+          "maxDescriptors": {
+            "name": "maxDescriptors",
+            "type": "Integer"
+          }
+        }
+      },
+      "getProcessMemoryInfo": {
+        "name": "getProcessMemoryInfo",
+        "signature": "()",
+        "description": "Returns an object giving memory usage statistics about the current process. Note that all statistics are reported in Kilobytes.",
+        "returns": {
+          "type": "Object",
+          "properties": [
+            {
+              "name": "workingSetSize",
+              "type": "Integer",
+              "description": "The amount of memory currently pinned to actual physical RAM."
+            },
+            {
+              "name": "peakWorkingSetSize",
+              "type": "Integer",
+              "description": "The maximum amount of memory that has ever been pinned to actual physical RAM."
+            },
+            {
+              "name": "privateBytes",
+              "type": "Integer",
+              "description": "The amount of memory not shared by other processes, such as JS heap or HTML content."
+            },
+            {
+              "name": "sharedBytes",
+              "type": "Integer",
+              "description": "The amount of memory shared between processes, typically memory consumed by the Electron code itself"
+            }
+          ]
+        }
+      },
+      "getSystemMemoryInfo": {
+        "name": "getSystemMemoryInfo",
+        "signature": "()",
+        "description": "Returns an object giving memory usage statistics about the entire system. Note that all statistics are reported in Kilobytes.",
+        "returns": {
+          "type": "Object",
+          "properties": [
+            {
+              "name": "total",
+              "type": "Integer",
+              "description": "The total amount of physical memory in Kilobytes available to the system."
+            },
+            {
+              "name": "free",
+              "type": "Integer",
+              "description": "The total amount of memory not being used by applications or disk cache."
+            },
+            {
+              "name": "swapTotal",
+              "type": "Integer",
+              "description": "The total amount of swap memory in Kilobytes available to the system."
+            },
+            {
+              "name": "swapFree",
+              "type": "Integer",
+              "description": "The free amount of swap memory in Kilobytes available to the system."
+            }
+          ]
+        }
+      }
+    },
+    "events": {
+      "loaded": {
+        "name": "loaded",
+        "description": "Emitted when Electron has loaded its internal initialization script and is beginning to load the web page or the main script. It can be used by the preload script to add removed Node global symbols back to the global scope when node integration is turned off:"
+      }
+    }
+  },
+  "desktopCapturer": {
+    "name": "desktopCapturer",
+    "description": "Access information about media sources that can be used to capture audio and\nvideo from the desktop using the navigator.webkitGetUserMedia API.",
+    "process": {
+      "main": false,
+      "renderer": true
+    },
+    "type": "Module",
+    "slug": "desktop-capturer",
+    "websiteUrl": "http://electron.atom.io/docs/api/desktop-capturer",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/desktop-capturer.md",
+    "methods": {
+      "getSources": {
+        "name": "getSources",
+        "signature": "(options, callback)",
+        "description": "Starts gathering information about all available desktop media sources, and calls callback(error, sources) when finished. sources is an array of Source objects, each Source represents a screen or an individual window that can be captured, and has the following properties:",
+        "parameters": {
+          "options": {
+            "name": "options",
+            "type": "Object",
+            "properties": {
+              "types": {
+                "name": "types",
+                "type": "String[]",
+                "description": "An array of Strings that lists the types of desktop sources to be captured, available types are and ."
+              },
+              "thumbnailSize": {
+                "name": "thumbnailSize",
+                "type": "Object",
+                "description": "(optional) - The suggested size that the media source thumbnail should be scaled to, defaults to .",
+                "properties": {}
+              }
+            }
+          },
+          "callback": {
+            "name": "callback",
+            "type": "Function"
+          }
+        }
+      }
+    }
+  },
+  "ipcRenderer": {
+    "name": "ipcRenderer",
+    "description": "Communicate asynchronously from a renderer process to the main process.",
+    "process": {
+      "main": false,
+      "renderer": true
+    },
+    "type": "Module",
+    "slug": "ipc-renderer",
+    "websiteUrl": "http://electron.atom.io/docs/api/ipc-renderer",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/ipc-renderer.md"
+  },
+  "remote": {
+    "name": "remote",
+    "description": "Use main process modules from the renderer process.",
+    "process": {
+      "main": false,
+      "renderer": true
+    },
+    "type": "Module",
+    "slug": "remote",
+    "websiteUrl": "http://electron.atom.io/docs/api/remote",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/remote.md",
+    "methods": {
+      "require": {
+        "name": "require",
+        "signature": "(module)",
+        "parameters": {
+          "module": {
+            "name": "module",
+            "type": "String"
+          }
+        },
+        "returns": {
+          "type": "Object",
+          "description": "The object returned by require(module) in the main process.",
+          "properties": [
+            {
+              "name": "module",
+              "type": "String",
+              "description": ""
+            }
+          ]
+        }
+      },
+      "getCurrentWindow": {
+        "name": "getCurrentWindow",
+        "signature": "()",
+        "returns": {
+          "type": "BrowserWindow",
+          "description": "The BrowserWindow object to which this web page belongs."
+        }
+      },
+      "getCurrentWebContents": {
+        "name": "getCurrentWebContents",
+        "signature": "()",
+        "returns": {
+          "type": "WebContents",
+          "description": "The WebContents object of this web page."
+        }
+      },
+      "getGlobal": {
+        "name": "getGlobal",
+        "signature": "(name)",
+        "parameters": {
+          "name": {
+            "name": "name",
+            "type": "String"
+          }
+        },
+        "returns": {
+          "type": "any",
+          "description": "The global variable of name (e.g. global[name]) in the main process."
+        }
+      }
+    }
+  },
+  "webFrame": {
+    "name": "webFrame",
+    "description": "Customize the rendering of the current web page.",
+    "process": {
+      "main": false,
+      "renderer": true
+    },
+    "type": "Module",
+    "slug": "web-frame",
+    "websiteUrl": "http://electron.atom.io/docs/api/web-frame",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/web-frame.md",
+    "methods": {
+      "setZoomFactor": {
+        "name": "setZoomFactor",
+        "signature": "(factor)",
+        "description": "Changes the zoom factor to the specified factor. Zoom factor is zoom percent divided by 100, so 300% = 3.0.",
+        "parameters": {
+          "factor": {
+            "name": "factor",
+            "type": "Number",
+            "description": "Zoom factor."
+          }
+        }
+      },
+      "getZoomFactor": {
+        "name": "getZoomFactor",
+        "signature": "()",
+        "returns": {
+          "type": "Number",
+          "description": "The current zoom factor."
+        }
+      },
+      "setZoomLevel": {
+        "name": "setZoomLevel",
+        "signature": "(level)",
+        "description": "Changes the zoom level to the specified level. The original size is 0 and each increment above or below represents zooming 20% larger or smaller to default limits of 300% and 50% of original size, respectively.",
+        "parameters": {
+          "level": {
+            "name": "level",
+            "type": "Number",
+            "description": "Zoom level"
+          }
+        }
+      },
+      "getZoomLevel": {
+        "name": "getZoomLevel",
+        "signature": "()",
+        "returns": {
+          "type": "Number",
+          "description": "The current zoom level."
+        }
+      },
+      "setZoomLevelLimits": {
+        "name": "setZoomLevelLimits",
+        "signature": "(minimumLevel, maximumLevel)",
+        "description": "Sets the maximum and minimum zoom level.",
+        "parameters": {
+          "minimumLevel": {
+            "name": "minimumLevel",
+            "type": "Number"
+          },
+          "maximumLevel": {
+            "name": "maximumLevel",
+            "type": "Number"
+          }
+        }
+      },
+      "setSpellCheckProvider": {
+        "name": "setSpellCheckProvider",
+        "signature": "(language, autoCorrectWord, provider)",
+        "description": "Sets a provider for spell checking in input fields and text areas. The provider must be an object that has a spellCheck method that returns whether the word passed is correctly spelled. An example of using node-spellchecker as provider:",
+        "parameters": {
+          "language": {
+            "name": "language",
+            "type": "String"
+          },
+          "autoCorrectWord": {
+            "name": "autoCorrectWord",
+            "type": "Boolean"
+          },
+          "provider": {
+            "name": "provider",
+            "type": "Object"
+          }
+        }
+      },
+      "registerURLSchemeAsSecure": {
+        "name": "registerURLSchemeAsSecure",
+        "signature": "(scheme)",
+        "description": "Registers the scheme as secure scheme. Secure schemes do not trigger mixed content warnings. For example, https and data are secure schemes because they cannot be corrupted by active network attackers.",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          }
+        }
+      },
+      "registerURLSchemeAsBypassingCSP": {
+        "name": "registerURLSchemeAsBypassingCSP",
+        "signature": "(scheme)",
+        "description": "Resources will be loaded from this scheme regardless of the current page's Content Security Policy.",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          }
+        }
+      },
+      "registerURLSchemeAsPrivileged": {
+        "name": "registerURLSchemeAsPrivileged",
+        "signature": "(scheme)",
+        "description": "Registers the scheme as secure, bypasses content security policy for resources, allows registering ServiceWorker and supports fetch API.",
+        "parameters": {
+          "scheme": {
+            "name": "scheme",
+            "type": "String"
+          }
+        }
+      },
+      "insertText": {
+        "name": "insertText",
+        "signature": "(text)",
+        "description": "Inserts text to the focused element.",
+        "parameters": {
+          "text": {
+            "name": "text",
+            "type": "String"
+          }
+        }
+      },
+      "executeJavaScript": {
+        "name": "executeJavaScript",
+        "signature": "(code[, userGesture])",
+        "description": "Evaluates code in page. In the browser window some HTML APIs like requestFullScreen can only be invoked by a gesture from the user. Setting userGesture to true will remove this limitation.",
+        "parameters": {
+          "code": {
+            "name": "code",
+            "type": "String"
+          },
+          "userGesture": {
+            "name": "userGesture",
+            "type": "Boolean",
+            "description": "(optional) - Default is `false`."
+          }
+        }
+      },
+      "getResourceUsage": {
+        "name": "getResourceUsage",
+        "signature": "()",
+        "description": "Returns an object describing usage information of Blink's internal memory caches. This will generate:",
+        "returns": {
+          "type": "Object",
+          "properties": [
+            {
+              "name": "images",
+              "type": "MemoryUsageDetails",
+              "description": ""
+            },
+            {
+              "name": "cssStyleSheets",
+              "type": "MemoryUsageDetails",
+              "description": ""
+            },
+            {
+              "name": "xslStyleSheets",
+              "type": "MemoryUsageDetails",
+              "description": ""
+            },
+            {
+              "name": "fonts",
+              "type": "MemoryUsageDetails",
+              "description": ""
+            },
+            {
+              "name": "other",
+              "type": "MemoryUsageDetails",
+              "description": ""
+            }
+          ]
+        }
+      },
+      "clearCache": {
+        "name": "clearCache",
+        "signature": "()",
+        "description": "Attempts to free memory that is no longer being used (like images from a previous navigation). Note that blindly calling this method probably makes Electron slower since it will have to refill these emptied caches, you should only call it if an event in your app has occurred that makes you think your page is actually using less memory (i.e. you have navigated from a super heavy page to a mostly empty one, and intend to stay there)."
+      }
+    }
+  },
+  "BrowserWindowProxy": {
+    "name": "BrowserWindowProxy",
+    "description": "Manipulate the child browser window",
+    "process": {
+      "main": false,
+      "renderer": true
+    },
+    "type": "Class",
+    "slug": "browser-window-proxy",
+    "websiteUrl": "http://electron.atom.io/docs/api/browser-window-proxy",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/browser-window-proxy.md",
+    "instanceName": "win",
+    "instanceMethods": {
+      "blur": {
+        "name": "blur",
+        "signature": "()",
+        "description": "Removes focus from the child window."
+      },
+      "close": {
+        "name": "close",
+        "signature": "()",
+        "description": "Forcefully closes the child window without calling its unload event."
+      },
+      "eval": {
+        "name": "eval",
+        "signature": "(code)",
+        "description": "Evaluates the code in the child window.",
+        "parameters": {
+          "code": {
+            "name": "code",
+            "type": "String"
+          }
+        }
+      },
+      "focus": {
+        "name": "focus",
+        "signature": "()",
+        "description": "Focuses the child window (brings the window to front)."
+      },
+      "print": {
+        "name": "print",
+        "signature": "()",
+        "description": "Invokes the print dialog on the child window."
+      },
+      "postMessage": {
+        "name": "postMessage",
+        "signature": "(message, targetOrigin)",
+        "description": "Sends a message to the child window with the specified origin or * for no origin preference. In addition to these methods, the child window implements window.opener object with no properties and a single method.",
+        "parameters": {
+          "message": {
+            "name": "message",
+            "type": "String"
+          },
+          "targetOrigin": {
+            "name": "targetOrigin",
+            "type": "String"
+          }
+        }
+      }
+    },
+    "instanceProperties": {
+      "closed": {
+        "name": "closed",
+        "description": "A Boolean that is set to true after the child window gets closed."
+      }
+    }
+  },
+  "Certificate": {
+    "name": "Certificate",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Structure",
+    "slug": "certificate",
+    "websiteUrl": "http://electron.atom.io/docs/api/structures/certificate",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/structures/certificate.md",
+    "properties": {
+      "data": {
+        "name": "data",
+        "type": "String",
+        "description": "PEM encoded data"
+      },
+      "issuerName": {
+        "name": "issuerName",
+        "type": "String",
+        "description": "Issuer's Common Name"
+      },
+      "subjectName": {
+        "name": "subjectName",
+        "type": "String",
+        "description": "Subject's Common Name"
+      },
+      "serialNumber": {
+        "name": "serialNumber",
+        "type": "String",
+        "description": "Hex value represented string"
+      },
+      "validStart": {
+        "name": "validStart",
+        "type": "Number",
+        "description": "Start date of the certificate being valid in seconds"
+      },
+      "validExpiry": {
+        "name": "validExpiry",
+        "type": "Number",
+        "description": "End date of the certificate being valid in seconds"
+      },
+      "fingerprint": {
+        "name": "fingerprint",
+        "type": "String",
+        "description": "Fingerprint of the certificate"
+      }
+    }
+  },
+  "Display": {
+    "name": "Display",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Structure",
+    "slug": "display",
+    "websiteUrl": "http://electron.atom.io/docs/api/structures/display",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/structures/display.md",
+    "properties": {
+      "id": {
+        "name": "id",
+        "type": "Number",
+        "description": "Unique identifier associated with the display."
+      },
+      "rotation": {
+        "name": "rotation",
+        "type": "Number",
+        "description": "Can be 0, 90, 180, 270, represents screen rotation in clock-wise degrees."
+      },
+      "scaleFactor": {
+        "name": "scaleFactor",
+        "type": "Number",
+        "description": "Output device's pixel scale factor."
+      },
+      "touchSupport": {
+        "name": "touchSupport",
+        "type": "String",
+        "description": "Can be , , ."
+      },
+      "bounds": {
+        "name": "bounds",
+        "type": "Rectangle",
+        "description": ""
+      },
+      "size": {
+        "name": "size",
+        "type": "Object",
+        "description": "",
+        "properties": {
+          "height": {
+            "name": "height",
+            "type": "Number",
+            "description": ""
+          },
+          "width": {
+            "name": "width",
+            "type": "Number",
+            "description": ""
+          }
+        }
+      },
+      "workArea": {
+        "name": "workArea",
+        "type": "Rectangle",
+        "description": ""
+      },
+      "workAreaSize": {
+        "name": "workAreaSize",
+        "type": "Object",
+        "description": "",
+        "properties": {
+          "height": {
+            "name": "height",
+            "type": "Number",
+            "description": ""
+          },
+          "width": {
+            "name": "width",
+            "type": "Number",
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "JumpListCategory": {
+    "name": "JumpListCategory",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Structure",
+    "slug": "jump-list-category",
+    "websiteUrl": "http://electron.atom.io/docs/api/structures/jump-list-category",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/structures/jump-list-category.md",
+    "properties": {
+      "type": {
+        "name": "type",
+        "type": "String",
+        "description": "One of the following:"
+      },
+      "name": {
+        "name": "name",
+        "type": "String",
+        "description": "Must be set if is , otherwise it should be omitted."
+      },
+      "items": {
+        "name": "items",
+        "type": "JumpListItem[]",
+        "description": "Array of objects if is or , otherwise it should be omitted."
+      }
+    }
+  },
+  "JumpListItem": {
+    "name": "JumpListItem",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Structure",
+    "slug": "jump-list-item",
+    "websiteUrl": "http://electron.atom.io/docs/api/structures/jump-list-item",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/structures/jump-list-item.md",
+    "properties": {
+      "type": {
+        "name": "type",
+        "type": "String",
+        "description": "One of the following:"
+      },
+      "path": {
+        "name": "path",
+        "type": "String",
+        "description": "Path of the file to open, should only be set if is ."
+      },
+      "program": {
+        "name": "program",
+        "type": "String",
+        "description": "Path of the program to execute, usually you should specify which opens the current program. Should only be set if is ."
+      },
+      "args": {
+        "name": "args",
+        "type": "String",
+        "description": "The command line arguments when is executed. Should only be set if is ."
+      },
+      "title": {
+        "name": "title",
+        "type": "String",
+        "description": "The text to be displayed for the item in the Jump List. Should only be set if is ."
+      },
+      "description": {
+        "name": "description",
+        "type": "String",
+        "description": "Description of the task (displayed in a tooltip). Should only be set if is ."
+      },
+      "iconPath": {
+        "name": "iconPath",
+        "type": "String",
+        "description": "The absolute path to an icon to be displayed in a Jump List, which can be an arbitrary resource file that contains an icon (e.g. , , ). You can usually specify to show the program icon."
+      },
+      "iconIndex": {
+        "name": "iconIndex",
+        "type": "Number",
+        "description": "The index of the icon in the resource file. If a resource file contains multiple icons this value can be used to specify the zero-based index of the icon that should be displayed for this task. If a resource file contains only one icon, this property should be set to zero."
+      }
+    }
+  },
+  "MemoryUsageDetails": {
+    "name": "MemoryUsageDetails",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Structure",
+    "slug": "memory-usage-details",
+    "websiteUrl": "http://electron.atom.io/docs/api/structures/memory-usage-details",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/structures/memory-usage-details.md",
+    "properties": {
+      "count": {
+        "name": "count",
+        "type": "Number",
+        "description": ""
+      },
+      "size": {
+        "name": "size",
+        "type": "Number",
+        "description": ""
+      },
+      "liveSize": {
+        "name": "liveSize",
+        "type": "Number",
+        "description": ""
+      },
+      "decodedSize": {
+        "name": "decodedSize",
+        "type": "Number",
+        "description": ""
+      },
+      "purgedSize": {
+        "name": "purgedSize",
+        "type": "Number",
+        "description": ""
+      },
+      "purgeableSize": {
+        "name": "purgeableSize",
+        "type": "Number",
+        "description": ""
+      }
+    }
+  },
+  "Rectangle": {
+    "name": "Rectangle",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Structure",
+    "slug": "rectangle",
+    "websiteUrl": "http://electron.atom.io/docs/api/structures/rectangle",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/structures/rectangle.md",
+    "properties": {
+      "x": {
+        "name": "x",
+        "type": "Number",
+        "description": "The x coordinate of the origin of the rectangle"
+      },
+      "y": {
+        "name": "y",
+        "type": "Number",
+        "description": "The y coordinate of the origin of the rectangle"
+      },
+      "width": {
+        "name": "width",
+        "type": "Number",
+        "description": ""
+      },
+      "height": {
+        "name": "height",
+        "type": "Number",
+        "description": ""
+      }
+    }
+  },
+  "ShortcutDetails": {
+    "name": "ShortcutDetails",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Structure",
+    "slug": "shortcut-details",
+    "websiteUrl": "http://electron.atom.io/docs/api/structures/shortcut-details",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/structures/shortcut-details.md",
+    "properties": {
+      "target": {
+        "name": "target",
+        "type": "String",
+        "description": "The target to launch from this shortcut."
+      },
+      "cwd": {
+        "name": "cwd",
+        "type": "String",
+        "description": "(optional) - The working directory. Default is empty."
+      },
+      "args": {
+        "name": "args",
+        "type": "String",
+        "description": "(optional) - The arguments to be applied to when launching from this shortcut. Default is empty."
+      },
+      "description": {
+        "name": "description",
+        "type": "String",
+        "description": "(optional) - The description of the shortcut. Default is empty."
+      },
+      "icon": {
+        "name": "icon",
+        "type": "String",
+        "description": "(optional) - The path to the icon, can be a DLL or EXE. and have to be set together. Default is empty, which uses the target's icon."
+      },
+      "iconIndex": {
+        "name": "iconIndex",
+        "type": "Number",
+        "description": "(optional) - The resource ID of icon when is a DLL or EXE. Default is 0."
+      },
+      "appUserModelId": {
+        "name": "appUserModelId",
+        "type": "String",
+        "description": "(optional) - The Application User Model ID. Default is empty."
+      }
+    }
+  },
+  "Task": {
+    "name": "Task",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Structure",
+    "slug": "task",
+    "websiteUrl": "http://electron.atom.io/docs/api/structures/task",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/structures/task.md",
+    "properties": {
+      "program": {
+        "name": "program",
+        "type": "String",
+        "description": "Path of the program to execute, usually you should specify which opens the current program."
+      },
+      "arguments": {
+        "name": "arguments",
+        "type": "String",
+        "description": "The command line arguments when is executed."
+      },
+      "title": {
+        "name": "title",
+        "type": "String",
+        "description": "The string to be displayed in a JumpList."
+      },
+      "description": {
+        "name": "description",
+        "type": "String",
+        "description": "Description of this task."
+      },
+      "iconPath": {
+        "name": "iconPath",
+        "type": "String",
+        "description": "The absolute path to an icon to be displayed in a JumpList, which can be an arbitrary resource file that contains an icon. You can usually specify to show the icon of the program."
+      },
+      "iconIndex": {
+        "name": "iconIndex",
+        "type": "Number",
+        "description": "The icon index in the icon file. If an icon file consists of two or more icons, set this value to identify the icon. If an icon file consists of one icon, this value is 0."
+      }
+    }
+  },
+  "ThumbarButton": {
+    "name": "ThumbarButton",
+    "process": {
+      "main": true,
+      "renderer": true
+    },
+    "type": "Structure",
+    "slug": "thumbar-button",
+    "websiteUrl": "http://electron.atom.io/docs/api/structures/thumbar-button",
+    "repoUrl": "https://github.com/electron/electron/blob/v1.4.4/docs/api/structures/thumbar-button.md",
+    "properties": {
+      "icon": {
+        "name": "icon",
+        "type": "NativeImage",
+        "description": "The icon showing in thumbnail toolbar."
+      },
+      "click": {
+        "name": "click",
+        "type": "Function",
+        "description": ""
+      },
+      "tooltip": {
+        "name": "tooltip",
+        "type": "String",
+        "description": "(optional) - The text of the button's tooltip."
+      },
+      "flags": {
+        "name": "flags",
+        "type": "String[]",
+        "description": "(optional) - Control specific states and behaviors of the button. By default, it is ."
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR allows the API data to be consumed as a JSON tree, to enable explorable tree interfaces like [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc)

Here's the raw JSON tree, since it's too big for GitHub to display inline: https://cldup.com/ofyyPoQiOk.json

@kevinsawicki @groundwater @MarshallOfSound 
