### PR TITLE
nativeImage value for name key changed to NativeImage

### DIFF
--- a/electron-api.json
+++ b/electron-api.json
@@ -6338,7 +6338,7 @@
     ]
   },
   {
-    "name": "nativeImage",
+    "name": "NativeImage",
     "description": "Create tray, dock, and application icons using PNG or JPG files.",
     "process": {
       "main": true,


### PR DESCRIPTION
I am using this json file to generate Scala.js facade types,  noticed this minor mistake.

Not sure where this json is generated from.