### PR TITLE
2nd param of <WebviewTag>.executeJavaScript is not required

### DIFF
--- a/electron-api.json
+++ b/electron-api.json
@@ -16933,7 +16933,7 @@
             "type": "Boolean",
             "collection": false,
             "description": "Default `false`.",
-            "required": true
+            "required": false
           },
           {
             "name": "callback",


### PR DESCRIPTION
From doc:

> userGesture Boolean - Default false.

https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#webviewexecutejavascriptcode-usergesture-callback

`userGesture` should be optional.